### PR TITLE
Literal type

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,10 +230,11 @@ The available schema types are shown below.
 - `q.string`, corresponds to [Zod's string type](https://github.com/colinhacks/zod#strings).
 - `q.number`, corresponds to [Zod's number type](https://github.com/colinhacks/zod#numbers).
 - `q.boolean`, corresponds to [Zod's boolean type](https://github.com/colinhacks/zod#booleans).
+- `q.literal`, corresponds to [Zod's literal type](https://github.com/colinhacks/zod#literals).
+- `q.union`, corresponds to [Zod's union type](https://github.com/colinhacks/zod#unions).
 - `q.date`, which is a custom Zod schema that can accept `Date` instances _or_ a date string (and it will transform that date string to a `Date` instance).
 - `q.null`, corresponds to Zod's null type.
 - `q.undefined`, corresponds to Zod's undefined type.
-
 ### `makeSafeQueryRunner`
 
 A wrapper around `q` so you can easily use `groqd` with an actual fetch implementation. 
@@ -269,4 +270,22 @@ import type { InferType } from "groqd";
 
 const query = q("*", q.grab({ name: q.string(), age: q.number() }));
 type Persons = InferType<typeof query>; // -> { name: string; age: number; }[]
+```
+
+## FAQs
+
+### Can `groqd` handle groq's `coalesce` operator?
+
+**Yes!** You can write a colesce expression just as if it were a field expression. Here's an example with `groqd`:
+
+```ts
+q(
+  "*",
+  q.filter("_type == 'pokemon'"),
+  q.grab({
+    name: q.string(),
+    // using `coalesce` in a `grab` call
+    strength: ["coalesce(strength, base.Attack, 0)", q.number()]
+  }),
+);
 ```

--- a/src/grab.test.ts
+++ b/src/grab.test.ts
@@ -77,4 +77,23 @@ describe("grab", () => {
     expect(data.name).toBe("Grass");
     expect(data.pokemons[0].name).toBe("Bulbasaur");
   });
+
+  it("can handle coalesce statements", async () => {
+    const { query, data } = await runPokemonQuery(
+      q(
+        "*",
+        q.filter("_type == 'pokemon'"),
+        q.slice(0, 3),
+        q.grab({
+          strength: ["coalesce(attack, base.Attack)", q.number()],
+        })
+      )
+    );
+
+    expect(query).toBe(
+      `*[_type == 'pokemon'][0..3]{"strength": coalesce(attack, base.Attack)}`
+    );
+    invariant(data);
+    expect(data[0].strength).toBe(49);
+  });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { runPokemonQuery } from "../test-utils/runQuery";
+import { q } from "./index";
+import invariant from "tiny-invariant";
+
+describe("literal", () => {
+  it("will generate a literal string type", async () => {
+    const { data, query } = await runPokemonQuery(
+      q(
+        "*",
+        q.filter("_type == 'pokemon'"),
+        q.slice(0),
+        q.grab({
+          name: q.literal("Bulbasaur"),
+        })
+      )
+    );
+
+    expect(query).toBe(`*[_type == 'pokemon'][0]{name}`);
+    invariant(data);
+    const name = data.name;
+    expect(name === "Bulbasaur").toBeTruthy();
+    // @ts-expect-error Anything but Bulbasaur should throw type error
+    expect(name === "Charmander").toBeFalsy();
+  });
+
+  it("will generate a literal number type", async () => {
+    const { data, query } = await runPokemonQuery(
+      q(
+        "*",
+        q.filter("_type == 'pokemon'"),
+        q.slice(0),
+        q.grab({
+          hp: ["base.HP", q.literal(45)],
+        })
+      )
+    );
+
+    expect(query).toBe(`*[_type == 'pokemon'][0]{"hp": base.HP}`);
+    invariant(data);
+    const hp = data.hp;
+    expect(hp === 45).toBeTruthy();
+    // @ts-expect-error Anything but 45 should throw type error
+    expect(hp === 50).toBeFalsy();
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -94,7 +94,7 @@ pipe.null = z.null;
 pipe.undefined = z.undefined;
 pipe.date = () => dateSchema;
 pipe.literal = z.literal;
-// TODO: pipe.union...?
+pipe.union = z.union;
 // TODO: pipe.enum?
 
 // Our main export is the pipe, renamed as q

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,8 +93,9 @@ pipe.unknown = z.unknown;
 pipe.null = z.null;
 pipe.undefined = z.undefined;
 pipe.date = () => dateSchema;
+pipe.literal = z.literal;
 // TODO: pipe.union...?
-// TODO: pipe.literal? pipe.enum?
+// TODO: pipe.enum?
 
 // Our main export is the pipe, renamed as q
 export const q = pipe;


### PR DESCRIPTION
Address #10 and #11 : 

- Adds support for a `q.literal` type (that just wraps Zod's `z.literal`).
- (bonus points) Adds support for `q.union` type (that just wraps Zod's `z.union`).
- Adds tests and README deets on using groq's `coalesce` operator.