### PR TITLE
`.deref` on `UnknownQuery`

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -61,6 +61,11 @@ export class UnknownQuery extends EntityQuery<z.ZodUnknown> {
       schema: z.array(z.unknown()),
     });
   }
+
+  deref() {
+    this.query += "->";
+    return this;
+  }
 }
 
 /**

--- a/test-utils/runQuery.ts
+++ b/test-utils/runQuery.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { evaluate, parse } from "groq-js";
 import { pokemonDataset } from "./pokemon";
 import { BaseQuery } from "../src/builder";
+import { userDataset } from "./users";
 
 const makeQueryRunner =
   (dataset: any[]) =>
@@ -28,4 +29,7 @@ const makeQueryRunner =
       };
     }
   };
+
 export const runPokemonQuery = makeQueryRunner(pokemonDataset);
+
+export const runUserQuery = makeQueryRunner(userDataset);

--- a/test-utils/users.ts
+++ b/test-utils/users.ts
@@ -1,0 +1,22 @@
+const userData: { name: string; age: number; role: RoleType }[] = [
+  { name: "John", age: 20, role: "guest" },
+  { name: "Jane", age: 30, role: "admin" },
+];
+
+const users = userData.map((user) => ({
+  _type: "user",
+  _id: `user.${user.name}`,
+  ...user,
+  role: {
+    _type: "reference",
+    _ref: `role.${user.role}`,
+  },
+}));
+
+type RoleType = "guest" | "admin";
+const roles: { _type: "role"; title: string; _id: `role.${RoleType}` }[] = [
+  { _type: "role", title: "guest", _id: "role.guest" },
+  { _type: "role", title: "admin", _id: "role.admin" },
+];
+
+export const userDataset = [...users, ...roles];


### PR DESCRIPTION
Allow for `deref` on `UnknownQuery`, addresses #26.