### PR TITLE
`q.object` helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ The available schema types are shown below.
 - `q.null`, corresponds to Zod's null type.
 - `q.undefined`, corresponds to Zod's undefined type.
 - `q.array`, corresponds to [Zod's array type](https://github.com/colinhacks/zod#arrays).
+- `q.object`, corresponds to [Zod's object type](https://github.com/colinhacks/zod#objects).
 
 ### `q.sanityImage`
 

--- a/src/schemas.test.ts
+++ b/src/schemas.test.ts
@@ -102,3 +102,23 @@ describe("date", () => {
     expect(data.createdAt).toBeInstanceOf(Date);
   });
 });
+
+describe("object", () => {
+  it("can handle objects without deeply specifying fields", async () => {
+    const { data, query } = await runPokemonQuery(
+      q("*")
+        .filter("_type == 'pokemon'")
+        .slice(0)
+        .grab({
+          types: q.array(
+            q.object({ _type: q.literal("reference"), _ref: q.string() })
+          ),
+        })
+    );
+
+    expect(query).toBe(`*[_type == 'pokemon'][0]{types}`);
+    invariant(data);
+    expect(data.types[0]._type === "reference").toBeTruthy();
+    expect(data.types[0]._ref === "type.Grass").toBeTruthy();
+  });
+});

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -16,4 +16,5 @@ export const schemas = {
   literal: z.literal,
   union: z.union,
   array: z.array,
+  object: z.object,
 };


### PR DESCRIPTION
Adds a `q.object` helper, which should help simplify some queries (will have follow-up PR with some examples).