### PR TITLE
Avoid `q.date()` in `q.sanityImage`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ const { query, schema } = q("*")
     name: q.string(),
     pokemons: q("*")
       .filter("_type == 'pokemon' && references(^._id)")
-      .grab({ name: q.string() })
+      .grab({ name: q.string() }),
   });
 
 // Use the schema and the query as you see fit, for example:
@@ -33,18 +33,17 @@ Since the primary use-case for `groqd` is actually executing GROQ queries and va
 import sanityClient from "@sanity/client";
 import { q, makeSafeQueryRunner } from "groqd";
 
-const client = sanityClient({ /* ... */});
+const client = sanityClient({
+  /* ... */
+});
 // 👇 Safe query runner
-export const runQuery = makeSafeQueryRunner(query => client.fetch(query));
+export const runQuery = makeSafeQueryRunner((query) => client.fetch(query));
 
 // ...
 
 // 👇 Now you can run queries and `data` is strongly-typed, and runtime-validated.
 const data = await runQuery(
-  q("*")
-    .filter("_type == 'pokemon'")
-    .grab({ name: q.string() })
-    .slice(0, 150)
+  q("*").filter("_type == 'pokemon'").grab({ name: q.string() }).slice(0, 150)
 );
 // data: { name: string }[]
 ```
@@ -53,7 +52,7 @@ Using `makeSafeQueryRunner` is totally optional; you might find using `q().schem
 
 ## **NOTE**: Significant API changes with 0.3.0
 
-Prior to version 0.3.0, `groqd` provided a pipeline API. However, there were some major drawbacks to that API. We've migrated to a builder pattern API that looks _similar_ to the previous API, but using a builder pattern (instead of piping). 
+Prior to version 0.3.0, `groqd` provided a pipeline API. However, there were some major drawbacks to that API. We've migrated to a builder pattern API that looks _similar_ to the previous API, but using a builder pattern (instead of piping).
 
 The core difference is instead of feeding all arguments to `q()`, `q()` accepts a single argument and then you chain method calls on that. For example:
 
@@ -94,8 +93,10 @@ import sanityClient from "@sanity/client";
 import { q, makeSafeQueryRunner } from "groqd";
 
 // Wrap sanityClient.fetch
-const client = sanityClient({ /* ... */});
-export const runQuery = makeSafeQueryRunner(query => client.fetch(query));
+const client = sanityClient({
+  /* ... */
+});
+export const runQuery = makeSafeQueryRunner((query) => client.fetch(query));
 
 // Now you can fetch your query's result, and validate the response, all in one.
 const data = await runQuery(q("*").filter("_type == 'pokemon'"));
@@ -103,14 +104,14 @@ const data = await runQuery(q("*").filter("_type == 'pokemon'"));
 
 ### `.grab`
 
-Available on `UnknownQuery`, `ArrayQuery`, and `EntityQuery`, handles [projections](https://www.sanity.io/docs/how-queries-work#727ecb6f5e15), or selecting fields from an existing set of documents. This is the primary mechanism for providing a schema for the data you expect to get. 
+Available on `UnknownQuery`, `ArrayQuery`, and `EntityQuery`, handles [projections](https://www.sanity.io/docs/how-queries-work#727ecb6f5e15), or selecting fields from an existing set of documents. This is the primary mechanism for providing a schema for the data you expect to get.
 
 `q.grab` accepts a "selection" object as its sole argument, with three different forms:
 
 ```ts
 q("*").grab({
   // projection is `{ "name": name }`, and validates that `name` is a string.
-  name: ['name', q.string()],
+  name: ["name", q.string()],
 
   // shorthand for `description: ['description', q.string()]`,
   //  projection is just `{ description }`
@@ -118,17 +119,16 @@ q("*").grab({
 
   // can also pass a sub-query for the field,
   //  projection is `{ "types": types[]->{ name } }`
-  types: q("types").filter().deref().grab({ name: q.string() })
+  types: q("types").filter().deref().grab({ name: q.string() }),
 });
 ```
 
 See [Schema Types](#schema-types) for available schema options, such as `q.string()`. These generally correspond to Zod primitives, so you can do something like:
 
 ```ts
-q("*")
-  .grab({
-    name: q.string().optional().default("no name")
-  });
+q("*").grab({
+  name: q.string().optional().default("no name"),
+});
 ```
 
 #### Conditional selections with `.grab`
@@ -136,13 +136,12 @@ q("*")
 Groq offers a `select` operator that you can use at the field-level to conditionally select values, such as the following.
 
 ```ts
-q("*")
-  .grab({
-    strength: [
-      "select(base.Attack > 60 => 'strong', base.Attack <= 60 => 'weak')",
-      q.union([q.literal("weak"), q.literal("strong")])
-    ],
-  });
+q("*").grab({
+  strength: [
+    "select(base.Attack > 60 => 'strong', base.Attack <= 60 => 'weak')",
+    q.union([q.literal("weak"), q.literal("strong")]),
+  ],
+});
 ```
 
 However, in real-world practice it's common to have an array of values of varying types and you want to select different values for each type. `.grab` allows you to do conditional selections by providing a second argument of the shape `{[condition: string]: Selection}`.
@@ -152,26 +151,33 @@ This second argument is not as flexible as the `=>` operator or `select` functio
 ```ts
 q("*")
   // Grab _id on all pokemon
-  .grab({
-    _id: q.string(),
-  }, {
-    // And for Bulbasaur, grab the HP
-    "name == 'Bulbasaur'": {
-      name: q.literal("Bulbasaur"),
-      hp: ["base.HP", q.number()]
+  .grab(
+    {
+      _id: q.string(),
     },
-    // And for Charmander, grab the Attack
-    "name == 'Charmander'": {
-      name: q.literal("Charmander"),
-      attack: ["base.Attack", q.number()]
-    },
-  });
+    {
+      // And for Bulbasaur, grab the HP
+      "name == 'Bulbasaur'": {
+        name: q.literal("Bulbasaur"),
+        hp: ["base.HP", q.number()],
+      },
+      // And for Charmander, grab the Attack
+      "name == 'Charmander'": {
+        name: q.literal("Charmander"),
+        attack: ["base.Attack", q.number()],
+      },
+    }
+  );
 
 // The query result type looks something like this:
-type QueryResult = ({_id: string; name: "Bulbasaur"; hp: number;} | {_id: string; name: "Charmander"; attack: number;} | {_id: string;})[]
+type QueryResult = (
+  | { _id: string; name: "Bulbasaur"; hp: number }
+  | { _id: string; name: "Charmander"; attack: number }
+  | { _id: string }
+)[];
 ```
 
-In real-world Sanity use-cases, it's likely you'll want to "fork" based on a `_type` field (or something similar). 
+In real-world Sanity use-cases, it's likely you'll want to "fork" based on a `_type` field (or something similar).
 
 **Important!** In the example above, if you were to add `name: q.string()` to the base selection, it would break TypeScript's ability to do discriminated union type narrowing. This is because if you have a type like `{name: "Charmander"} | {name: string}` there is no way to narrow types based on the `name` field (since for discriminated unions to work, the field must have a _literal_ type).
 
@@ -180,9 +186,7 @@ In real-world Sanity use-cases, it's likely you'll want to "fork" based on a `_t
 Similar to `q.grab`, but for ["naked" projections](https://www.sanity.io/docs/how-queries-work#dd66cae5ed8f) where you just need a single property (instead of an object of properties). Pass a property to be "grabbed", and a schema for the expected type.
 
 ```ts
-q("*")
-  .filter("_type == 'pokemon'")
-  .grabOne("name", q.string());
+q("*").filter("_type == 'pokemon'").grabOne("name", q.string());
 // -> string[]
 ```
 
@@ -200,9 +204,7 @@ q("*").filter("_type == 'pokemon'");
 Receives a list of ordering expression, such as `"name asc"`, and adds an order statement to the GROQ query.
 
 ```ts
-q("*")
-  .filter("_type == 'pokemon'")
-  .order("name asc");
+q("*").filter("_type == 'pokemon'").order("name asc");
 // translates to *[_type == 'pokemon']|order(name asc)
 ```
 
@@ -211,10 +213,7 @@ q("*")
 Creates a slice operation by taking a minimum index and an optional maximum index.
 
 ```ts
-q("*")
-  .filter("_type == 'pokemon'")
-  .grab({ name: q.string() })
-  .slice(0, 8);
+q("*").filter("_type == 'pokemon'").grab({ name: q.string() }).slice(0, 8);
 // translates to *[_type == 'pokemon']{name}[0..8]
 // -> { name: string }[]
 ```
@@ -222,10 +221,7 @@ q("*")
 The second argument can be omitted to grab a single document, and the schema/types are updated accordingly.
 
 ```ts
-q("*")
-  .filter("_type == 'pokemon'")
-  .grab({ name: q.string() })
-  .slice(0);
+q("*").filter("_type == 'pokemon'").grab({ name: q.string() }).slice(0);
 // -> { name: string }
 ```
 
@@ -239,7 +235,7 @@ q("*")
   .grab({
     name: q.string(),
     // example of grabbing types for a pokemon, and de-referencing to get name value.
-    types: q("types").filter().deref().grabOne("name", q.string())
+    types: q("types").filter().deref().grabOne("name", q.string()),
   });
 ```
 
@@ -267,12 +263,12 @@ q("*")
   .grab({
     // string field
     name: q.string(),
-    
+
     // number field
     hp: ["base.HP", q.number()],
-    
+
     // boolean field
-    isStrong: ["base.Attack > 50", q.boolean()]
+    isStrong: ["base.Attack > 50", q.boolean()],
   });
 ```
 
@@ -283,7 +279,7 @@ The available schema types are shown below.
 - `q.boolean`, corresponds to [Zod's boolean type](https://github.com/colinhacks/zod#booleans).
 - `q.literal`, corresponds to [Zod's literal type](https://github.com/colinhacks/zod#literals).
 - `q.union`, corresponds to [Zod's union type](https://github.com/colinhacks/zod#unions).
-- `q.date`, which is a custom Zod schema that can accept `Date` instances _or_ a date string (and it will transform that date string to a `Date` instance).
+- `q.date`, which is a custom Zod schema that can accept `Date` instances _or_ a date string (and it will transform that date string to a `Date` instance). **Warning**: Date objects are not serializable, so you might end up with a data object that can't be immediately serialized – potentially a problem if using `groqd` in e.g. a Next.js backend data fetch.
 - `q.null`, corresponds to Zod's null type.
 - `q.undefined`, corresponds to Zod's undefined type.
 - `q.array`, corresponds to [Zod's array type](https://github.com/colinhacks/zod#arrays).
@@ -362,8 +358,8 @@ q("*")
       additionalFields: {
         alt: q.string(),
         description: q.string(),
-      }
-    })
+      },
+    }),
   });
 
 // -> { cover: { ..., alt: string, description: string } }[]
@@ -388,17 +384,16 @@ q("*")
   .filter("_type == 'pokemon'")
   .grab({
     cover: q.sanityImage("cover", {
-      withAsset: ["base", "dimensions"]
-    })
+      withAsset: ["base", "dimensions"],
+    }),
   });
 
 // -> { cover: { ..., asset: { extension: string; mimeType: string; ...; metadata: { dimensions: { aspectRatio: number; height: number; width: number; }; }; }; } }[]
 ```
 
-
 ### `makeSafeQueryRunner`
 
-A wrapper around `q` so you can easily use `groqd` with an actual fetch implementation. 
+A wrapper around `q` so you can easily use `groqd` with an actual fetch implementation.
 
 Pass `makeSafeQueryRunner` a "query executor" of the shape `type QueryExecutor = (query: string) => Promise<any>`, and it will return a "query runner" function. This is best illustrated with an example:
 
@@ -407,21 +402,20 @@ import sanityClient from "@sanity/client";
 import { q } from "groqd";
 
 // Wrap sanityClient.fetch
-const client = sanityClient({ /* ... */});
-export const runQuery = makeSafeQueryRunner(query => client.fetch(query));
+const client = sanityClient({
+  /* ... */
+});
+export const runQuery = makeSafeQueryRunner((query) => client.fetch(query));
 
 // 👇 Now you can run queries and `data` is strongly-typed, and runtime-validated.
 const data = await runQuery(
-  q("*")
-    .filter("_type == 'pokemon'")
-    .grab({ name: q.string() })
-    .slice(0, 150)
+  q("*").filter("_type == 'pokemon'").grab({ name: q.string() }).slice(0, 150)
 );
 ```
 
 ### `InferType`
 
-A type utility to extract the TypeScript type for the data expected to be returned from the query. 
+A type utility to extract the TypeScript type for the data expected to be returned from the query.
 
 ```ts
 import { q } from "groqd";
@@ -443,6 +437,6 @@ q("*")
   .grab({
     name: q.string(),
     // using `coalesce` in a `grab` call
-    strength: ["coalesce(strength, base.Attack, 0)", q.number()]
+    strength: ["coalesce(strength, base.Attack, 0)", q.number()],
   });
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "groqd",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "license": "MIT",
   "author": {
     "name": "Formidable",

--- a/src/sanityImage.test.ts
+++ b/src/sanityImage.test.ts
@@ -170,7 +170,7 @@ describe("sanityImage", () => {
       im.asset.url ===
         "https://cdn.sanity.io/images/nfttuagc/production/ed158069c3b44124a310d7a107998e06bf12e90e-1000x500.jpg"
     ).toBeTruthy();
-    expect(im.asset._updatedAt instanceof Date).toBeTruthy();
+    expect(im.asset._updatedAt === "2022-12-12T19:45:48Z").toBeTruthy();
   });
 
   it("can query fetch image asset data with dimensions metadata", async () => {

--- a/src/sanityImage.ts
+++ b/src/sanityImage.ts
@@ -46,7 +46,7 @@ const dereffedAssetBaseFields = {
   sha1hash: schemas.string(),
   size: schemas.number(),
   url: schemas.string(),
-  _updatedAt: schemas.date(),
+  _updatedAt: schemas.string().nullable(),
 };
 
 const paletteFieldSchema = {


### PR DESCRIPTION
Since `Date` instances aren't JSON serializable, we run into issues trying to use `q.sanityImage` in a Next.js `getStaticProps` call since the Date values can't be sent over the wire as-is. This PR fixes that.