### PR TITLE
`q.contentBlock` helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,12 @@ The available schema types are shown below.
 - `q.undefined`, corresponds to Zod's undefined type.
 - `q.array`, corresponds to [Zod's array type](https://github.com/colinhacks/zod#arrays).
 - `q.object`, corresponds to [Zod's object type](https://github.com/colinhacks/zod#objects).
+- `q.contentBlock`, a custom Zod schema to match Sanity's `block` type, helpful for fetching data from a field that uses Sanity's block editor. For example:
+  ```ts
+  q("*")
+    .filter("_type == 'user'")
+    .grab({ body: q.array(q.contentBlock()) });
+  ```
 
 ### `q.sanityImage`
 

--- a/src/schemas.test.ts
+++ b/src/schemas.test.ts
@@ -122,3 +122,22 @@ describe("object", () => {
     expect(data.types[0]._ref === "type.Grass").toBeTruthy();
   });
 });
+
+describe("contentBlock", () => {
+  it("can handle content blocks", async () => {
+    const { data, query } = await runUserQuery(
+      q("*")
+        .filter("_type == 'user'")
+        .slice(0)
+        .grab({
+          name: q.string(),
+          bio: q.array(q.contentBlock()),
+        })
+    );
+
+    expect(query).toBe(`*[_type == 'user'][0]{name, bio}`);
+    invariant(data);
+    expect(Array.isArray(data.bio)).toBeTruthy();
+    expect(data.bio[0]._type === "block").toBeTruthy();
+  });
+});

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1,9 +1,42 @@
 import { z } from "zod";
 
+/**
+ * Custom date schema that will parse date strings to Date objects
+ */
 const dateSchema = () =>
   z.preprocess((arg) => {
     if (typeof arg == "string" || arg instanceof Date) return new Date(arg);
   }, z.date());
+
+/**
+ * Content block schema for standard content blocks.
+ */
+const contentBlock = () =>
+  z.object({
+    _type: z.literal("block"),
+    _key: z.string().optional(),
+    children: z.array(
+      z.object({
+        _key: z.string(),
+        _type: z.string(),
+        text: z.string(),
+        marks: z.array(z.string()),
+      })
+    ),
+    markDefs: z
+      .array(
+        z
+          .object({
+            _type: z.string(),
+            _key: z.string(),
+          })
+          .catchall(z.unknown())
+      )
+      .optional(),
+    style: z.string().optional(),
+    listItem: z.string().optional(),
+    level: z.number().optional(),
+  });
 
 export const schemas = {
   string: z.string,
@@ -17,4 +50,5 @@ export const schemas = {
   union: z.union,
   array: z.array,
   object: z.object,
+  contentBlock,
 };

--- a/test-utils/sampleContentBlocks.ts
+++ b/test-utils/sampleContentBlocks.ts
@@ -1,0 +1,74 @@
+export const sampleContentBlocks = [
+  {
+    _key: "4a8123d672e4_deduped_2",
+    _type: "block",
+    children: [
+      {
+        _key: "97d6b0fb822b",
+        _type: "span",
+        marks: [],
+        text: "Hello ",
+      },
+      {
+        _key: "0d916eef35d5",
+        _type: "span",
+        marks: ["strong"],
+        text: "world",
+      },
+      {
+        _key: "08d4552319d6",
+        _type: "span",
+        marks: [],
+        text: ", it ",
+      },
+      {
+        _key: "efac7033ea07",
+        _type: "span",
+        marks: ["37ac693910cb"],
+        text: "is",
+      },
+      {
+        _key: "a7935aa58cd7",
+        _type: "span",
+        marks: [],
+        text: " Pikachu.",
+      },
+    ],
+    markDefs: [
+      {
+        _key: "37ac693910cb",
+        _type: "link",
+        href: "https://google.com",
+      },
+    ],
+    style: "normal",
+  },
+  {
+    _key: "694615b411df",
+    _type: "block",
+    children: [
+      {
+        _key: "1d83c5becd42",
+        _type: "span",
+        marks: [],
+        text: "and some more",
+      },
+    ],
+    markDefs: [],
+    style: "h2",
+  },
+  {
+    _key: "7852cd508368",
+    _type: "block",
+    children: [
+      {
+        _key: "792a72f72a57",
+        _type: "span",
+        marks: [],
+        text: "and some more",
+      },
+    ],
+    markDefs: [],
+    style: "normal",
+  },
+];

--- a/test-utils/users.ts
+++ b/test-utils/users.ts
@@ -1,8 +1,11 @@
+import { sampleContentBlocks } from "./sampleContentBlocks";
+
 const userData: {
   name: string;
   age: number;
   role: RoleType;
   nicknames?: string[];
+  bio?: unknown;
 }[] = [
   {
     name: "John",
@@ -21,6 +24,7 @@ const users = userData.map((user) => ({
     _type: "reference",
     _ref: `role.${user.role}`,
   },
+  bio: sampleContentBlocks,
 }));
 
 type RoleType = "guest" | "admin";


### PR DESCRIPTION
Adding a little schema for `q.contentBlock` to make it easier to fetch content blocks from Sanity, useful with Sanity's WYSIWYG block editor. Addresses #32 