### PR TITLE
Add flexibility to `makeSafeQueryRunner`

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ q("*")
 
 A wrapper around `q` so you can easily use `groqd` with an actual fetch implementation.
 
-Pass `makeSafeQueryRunner` a "query executor" of the shape `type QueryExecutor = (query: string) => Promise<any>`, and it will return a "query runner" function. This is best illustrated with an example:
+Pass `makeSafeQueryRunner` a "query executor" of the shape `type QueryExecutor = (query: string, ...rest: any[]) => Promise<any>`, and it will return a "query runner" function. This is best illustrated with an example:
 
 ```ts
 import sanityClient from "@sanity/client";
@@ -416,6 +416,21 @@ export const runQuery = makeSafeQueryRunner((query) => client.fetch(query));
 // 👇 Now you can run queries and `data` is strongly-typed, and runtime-validated.
 const data = await runQuery(
   q("*").filter("_type == 'pokemon'").grab({ name: q.string() }).slice(0, 150)
+);
+```
+
+In Sanity workflows, you might also want to pass e.g. params to your `client.fetch` call. To support this, add additional arguments to your `makeSafeQueryRunner` argument's arguments as below.
+
+```ts
+// ...
+export const runQuery = makeSafeQueryRunner(
+  //      👇 add a second arg
+  (query, params: Record<string, unknown> = {}) => client.fetch(query, params)
+);
+
+const data = await runQuery(
+  q("*").filter("_type == 'pokemon' && _id == $id").grab({ name: q.string() }),
+  { id: "pokemon.1" } // 👈 and optionally pass them here.
 );
 ```
 

--- a/example/sanity-client-example.ts
+++ b/example/sanity-client-example.ts
@@ -1,9 +1,12 @@
 import sanityClient from "@sanity/client";
-import { makeSafeQueryRunner } from "../src";
+import { makeSafeQueryRunner, q } from "../src";
 
 const client = sanityClient({
   projectId: "your-project-id",
   apiVersion: "2021-03-25",
 });
 
-export const runQuery = makeSafeQueryRunner(client.fetch);
+export const runQuery = makeSafeQueryRunner(
+  (query: string, params: Record<string, unknown> = {}) =>
+    client.fetch(query, params)
+);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,10 @@
 import { z } from "zod";
-import { BaseQuery, UnknownQuery } from "./builder";
+import { UnknownQuery } from "./builder";
 import { sanityImage } from "./sanityImage";
 import { schemas } from "./schemas";
 
 export type { InferType } from "./types";
+export { makeSafeQueryRunner } from "./makeSafeQueryRunner";
 
 export const pipe = (filter: string): UnknownQuery => {
   return new UnknownQuery({ query: filter });
@@ -17,17 +18,6 @@ type Pipe = typeof pipe & typeof schemas;
 
 // Our main export is the pipe, renamed as q
 export const q = pipe as Pipe;
-
-type QueryExecutor = (query: string) => Promise<any>;
-
-/**
- * Utility to create a "query runner" that consumes the result of the `q` function.
- */
-type BaseType<T = any> = z.ZodType<T>;
-export const makeSafeQueryRunner =
-  (fn: QueryExecutor) =>
-  <T extends BaseType>({ query, schema }: BaseQuery<T>): Promise<z.infer<T>> =>
-    fn(query).then((res) => schema.parse(res));
 
 /**
  * Export zod for convenience

--- a/src/makeSafeQueryRunner.test.ts
+++ b/src/makeSafeQueryRunner.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from "vitest";
+import { q } from ".";
+import { makeSafeQueryRunner } from "./makeSafeQueryRunner";
+
+describe("makeSafeQueryRunner", () => {
+  it("should create a query runner with single argument", async () => {
+    const fn = vi.fn(() => Promise.resolve([]));
+    const runQuery = makeSafeQueryRunner(fn);
+
+    const res = await runQuery(q("*").filter().grab({ name: q.string() }));
+    expect(fn).toHaveBeenCalledWith(`*[]{name}`);
+    expect(res).toEqual([]);
+  });
+
+  it("should create a query runner with additional args defined by user", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const fn = vi.fn((query: string, params: Record<string, unknown>) =>
+      Promise.resolve([])
+    );
+    const runQuery = makeSafeQueryRunner(
+      (query, params: Record<string, unknown>) => fn(query, params)
+    );
+
+    const res = await runQuery(
+      q("*")
+        .filter(`_type == 'pokemon' && _id == $id`)
+        .grab({ name: q.string() }),
+      {
+        id: "123",
+      }
+    );
+    expect(fn).toHaveBeenCalledWith(
+      `*[_type == 'pokemon' && _id == $id]{name}`,
+      { id: "123" }
+    );
+    expect(res).toEqual([]);
+  });
+});

--- a/src/makeSafeQueryRunner.ts
+++ b/src/makeSafeQueryRunner.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+import { BaseQuery } from "./builder";
+
+/**
+ * Utility to create a "query runner" that consumes the result of the `q` function.
+ */
+type BaseType<T = any> = z.ZodType<T>;
+
+export const makeSafeQueryRunner =
+  <Fn extends (query: string, ...rest: any[]) => Promise<any>>(fn: Fn) =>
+  <T extends BaseType>(
+    { query, schema }: BaseQuery<T>,
+    ...rest: ButFirst<Parameters<Fn>>
+  ): Promise<z.infer<T>> =>
+    fn(query, ...rest).then((res) => schema.parse(res));
+
+type ButFirst<T extends unknown[]> = T extends [unknown, ...infer U]
+  ? U
+  : never;

--- a/src/makeSafeQueryRunner.ts
+++ b/src/makeSafeQueryRunner.ts
@@ -4,8 +4,6 @@ import { BaseQuery } from "./builder";
 /**
  * Utility to create a "query runner" that consumes the result of the `q` function.
  */
-type BaseType<T = any> = z.ZodType<T>;
-
 export const makeSafeQueryRunner =
   <Fn extends (query: string, ...rest: any[]) => Promise<any>>(fn: Fn) =>
   <T extends BaseType>(
@@ -14,6 +12,7 @@ export const makeSafeQueryRunner =
   ): Promise<z.infer<T>> =>
     fn(query, ...rest).then((res) => schema.parse(res));
 
+type BaseType<T = any> = z.ZodType<T>;
 type ButFirst<T extends unknown[]> = T extends [unknown, ...infer U]
   ? U
   : never;


### PR DESCRIPTION
Addresses #31 and adds some flexibility to `makeSafeQueryRunner` so that you can e.g. pass parameters via `sanity/client`'s params argument.