### PR TITLE
Extend InferType to accept zod schema

### DIFF
--- a/.changeset/cuddly-meals-tease.md
+++ b/.changeset/cuddly-meals-tease.md
@@ -1,0 +1,5 @@
+---
+"groqd": patch
+---
+
+Allow InferType to accept zod schema type

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -21,4 +21,23 @@ describe("InferType", () => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const res3: Res = [{ age: 30 }];
   });
+
+  it("can infer type from query schema", () => {
+    const { schema } = q("*")
+      .filter("_type == 'pokemon'")
+      .grab({ name: q.string() });
+
+    type Res = InferType<typeof schema>;
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const res: Res = [{ name: "Bulbasaur" }];
+
+    // @ts-expect-error Expecting error, since name is not of correct type
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const res2: Res = [{ name: 3 }];
+
+    // @ts-expect-error Expecting error, unknown field
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const res3: Res = [{ age: 30 }];
+  });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,8 @@ export type InferType<P> = P extends BaseQuery<infer T>
   ? T extends z.ZodType
     ? z.infer<T>
     : never
+  : P extends z.ZodType
+  ? z.infer<P>
   : never;
 
 /**


### PR DESCRIPTION
Allow `InferType` to accept Zod schema, for use-cases where you're destructuring `schema` out of your query:

```ts
import type { InferType } from "groqd";
import { q } from "groqd";

const query = q("*").filter().grab({ name: q.string() });
type Thing = InferType<typeof query>;

// OR!

const { schema } = q("*").filter().grab({ name: q.string() });
type Thing = InferType<typeof schema>;
```