### PR TITLE
Rage against the (`null`) machine

### DIFF
--- a/.changeset/lemon-rats-move.md
+++ b/.changeset/lemon-rats-move.md
@@ -1,0 +1,5 @@
+---
+"groqd": minor
+---
+
+nullToUndefined, grab$, and grabOne$ helpers to make dealing with null return values much more friendly.

--- a/README.md
+++ b/README.md
@@ -343,6 +343,19 @@ q("*")
   })
 ```
 
+The `nullToUndefined` helper can also accept a `Selection` object to apply to an entire selection.
+
+```ts
+q("*")
+  .filter("_type == 'pokemon'")
+  .grab(nullToUndefined({
+    name: q.string(),
+    foo: q.string().optional().default("bar"),
+  }))
+```
+
+Although we recommend just using `.grab$` in this case.
+
 ### `q.sanityImage`
 
 A convenience method to make it easier to generate image queries for Sanity's image type. Supports fetching various info from both `image` documents and `asset` documents.

--- a/README.md
+++ b/README.md
@@ -181,6 +181,20 @@ In real-world Sanity use-cases, it's likely you'll want to "fork" based on a `_t
 
 **Important!** In the example above, if you were to add `name: q.string()` to the base selection, it would break TypeScript's ability to do discriminated union type narrowing. This is because if you have a type like `{name: "Charmander"} | {name: string}` there is no way to narrow types based on the `name` field (since for discriminated unions to work, the field must have a _literal_ type).
 
+### `.grab$`
+
+Just like `.grab`, but uses the `nullToUndefined` helper [outlined below](#nulltoundefined) to convert `null` values to `undefined` which makes writing queries with "optional" values a bit easier.
+
+```ts
+q("*")
+  .filter("_type == 'pokemon'")
+  .grab$({
+    name: q.string(),
+    // 👇 `foo` comes in as `null`, but gets preprocessed to `undefined` so we can use `.optional()`.
+    foo: q.string().optional().default("bar"),
+  })
+```
+
 ### `.grabOne`
 
 Similar to `q.grab`, but for ["naked" projections](https://www.sanity.io/docs/how-queries-work#dd66cae5ed8f) where you just need a single property (instead of an object of properties). Pass a property to be "grabbed", and a schema for the expected type.
@@ -188,6 +202,16 @@ Similar to `q.grab`, but for ["naked" projections](https://www.sanity.io/docs/ho
 ```ts
 q("*").filter("_type == 'pokemon'").grabOne("name", q.string());
 // -> string[]
+```
+
+### `.grabOne$`
+
+Just like `.grabOne`, but uses the `nullToUndefined` helper [outlined below](#nulltoundefined) to convert `null` values to `undefined` which makes writing queries with "optional" values a bit easier.
+
+```ts
+q("*")
+  .filter("_type == 'pokemon'")
+  .grabOne$("name", q.string().optional());
 ```
 
 ### `.filter`
@@ -304,6 +328,20 @@ The available schema types are shown below.
     .filter("_type == 'user'")
     .grab({ body: q.array(q.contentBlock()) });
   ```
+  
+### `nullToUndefined`
+
+GROQ will return `null` if you query for a value that does not exist. This can lead to confusion when writing queries, because Zod's `.optional().default("default value")` doesn't work with null values. `groqd` ships with a `nullToUndefined` method that will preprocess `null` values into `undefined` to smooth over this rough edge.
+
+```ts
+q("*")
+  .filter("_type == 'pokemon'")
+  .grab({
+    name: q.string(),
+    // 👇 Missing field, allow us to set a default value when it doesn't exist
+    foo: nullToUndefined(q.string().optional().default("bar")),
+  })
+```
 
 ### `q.sanityImage`
 

--- a/src/builder.test.ts
+++ b/src/builder.test.ts
@@ -193,6 +193,33 @@ describe("grab$", () => {
     expect(data[0].name).toBe("Bulbasaur");
     expect(data[0].foo).toBe("bar");
   });
+
+  it("handles conditional selections", async () => {
+    const { data } = await runPokemonQuery(
+      q("*")
+        .filter("_type == 'pokemon'")
+        .slice(0)
+        .grab$(
+          { _id: q.string(), nahBrah: q.number().optional().default(69) },
+          {
+            "name == 'Bulbasaur'": {
+              name: q.literal("Bulbasaur"),
+              foo: q.string().optional().default("bar"),
+            },
+          }
+        )
+    );
+
+    invariant(data);
+    expect("name" in data).toBeTruthy();
+    expect("foo" in data).toBeTruthy();
+
+    expect(data.nahBrah).toBe(69);
+    if ("name" in data) {
+      expect(data.name).toBe("Bulbasaur");
+      expect(data.foo).toBe("bar");
+    }
+  });
 });
 
 describe("grabOne$", () => {

--- a/src/builder.test.ts
+++ b/src/builder.test.ts
@@ -149,6 +149,80 @@ describe("ArrayResult.grab/UnknownResult.grab/EntityResult.grab", () => {
   });
 });
 
+describe("grab$", () => {
+  it("coerces null to undefined on entity query", async () => {
+    const { data, query } = await runPokemonQuery(
+      q("*").filter("_type == 'pokemon'").slice(0).grab$({
+        name: q.string(),
+        foo: q.string().optional(),
+      })
+    );
+
+    expect(query).toBe(`*[_type == 'pokemon'][0]{name, foo}`);
+    invariant(data);
+    expect(data.name).toBe("Bulbasaur");
+    expect(data.foo).toBeUndefined();
+  });
+
+  it("coerces null to undefined on array query", async () => {
+    const { data, query } = await runPokemonQuery(
+      q("*").filter("_type == 'pokemon'").slice(0, 1).grab$({
+        name: q.string(),
+        foo: q.string().optional(),
+      })
+    );
+
+    expect(query).toBe(`*[_type == 'pokemon'][0..1]{name, foo}`);
+    invariant(data);
+    expect(data[0].name).toBe("Bulbasaur");
+    expect(data[0].foo).toBeUndefined();
+  });
+
+  it("works nice with default values", async () => {
+    const { data } = await runPokemonQuery(
+      q("*")
+        .filter("_type == 'pokemon'")
+        .slice(0, 1)
+        .grab$({
+          name: q.string(),
+          foo: q.string().optional().default("bar"),
+        })
+    );
+
+    invariant(data);
+    expect(data[0].name).toBe("Bulbasaur");
+    expect(data[0].foo).toBe("bar");
+  });
+});
+
+describe("grabOne$", () => {
+  it("coerces null to undefined on entity query", async () => {
+    const { data, query } = await runPokemonQuery(
+      q("*")
+        .filter("_type == 'pokemon'")
+        .slice(0)
+        .grabOne$("foo", q.string().optional())
+    );
+
+    expect(query).toBe(`*[_type == 'pokemon'][0].foo`);
+    expect(data).toBeUndefined();
+  });
+
+  it("coerces null to undefined on array query", async () => {
+    const { data, query } = await runPokemonQuery(
+      q("*")
+        .filter("_type == 'pokemon'")
+        .slice(0, 1)
+        .grabOne$("foo", q.string().optional())
+    );
+
+    expect(query).toBe(`*[_type == 'pokemon'][0..1].foo`);
+    invariant(data);
+    expect(data[0]).toBeUndefined();
+    expect(data[1]).toBeUndefined();
+  });
+});
+
 describe("UnknownResult.filter/ArrayResult.filter", () => {
   it("applies simple filter appropriately to UnknownResult, returning unknown array", async () => {
     const { query, schema, data } = await runPokemonQuery(

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { grab } from "./grab";
 import type { Selection } from "./grab";
+import { nullToUndefined } from "./nullToUndefined";
 
 type Query = string;
 type Payload<T extends z.ZodTypeAny> = { schema: T; query: Query };
@@ -49,6 +50,18 @@ export class EntityQuery<T extends z.ZodTypeAny> extends BaseQuery<T> {
     return grab(this.query, this.schema, selection, conditionalSelections);
   }
 
+  grab$<
+    S extends Selection,
+    CondSelections extends Record<string, Selection> | undefined
+  >(selection: S, conditionalSelections?: CondSelections) {
+    return grab(
+      this.query,
+      this.schema,
+      nullToUndefined(selection),
+      conditionalSelections
+    );
+  }
+
   grabOne<GrabOneType extends z.ZodType>(
     name: string,
     fieldSchema: GrabOneType
@@ -56,6 +69,16 @@ export class EntityQuery<T extends z.ZodTypeAny> extends BaseQuery<T> {
     return new EntityQuery<GrabOneType>({
       query: this.query + `.${name}`,
       schema: fieldSchema,
+    });
+  }
+
+  grabOne$<GrabOneType extends z.ZodType>(
+    name: string,
+    fieldSchema: GrabOneType
+  ) {
+    return new EntityQuery<z.ZodEffects<GrabOneType>>({
+      query: this.query + `.${name}`,
+      schema: nullToUndefined(fieldSchema),
     });
   }
 }
@@ -104,6 +127,18 @@ export class ArrayQuery<T extends z.ZodTypeAny> extends BaseQuery<
     return grab(this.query, this.schema, selection, conditionalSelections);
   }
 
+  grab$<
+    S extends Selection,
+    CondSelections extends Record<string, Selection> | undefined
+  >(selection: S, conditionalSelections?: CondSelections) {
+    return grab(
+      this.query,
+      this.schema,
+      nullToUndefined(selection),
+      conditionalSelections
+    );
+  }
+
   grabOne<GrabOneType extends z.ZodType>(
     name: string,
     fieldSchema: GrabOneType
@@ -111,6 +146,16 @@ export class ArrayQuery<T extends z.ZodTypeAny> extends BaseQuery<
     return new ArrayQuery<GrabOneType>({
       query: this.query + `.${name}`,
       schema: z.array(fieldSchema),
+    });
+  }
+
+  grabOne$<GrabOneType extends z.ZodType>(
+    name: string,
+    fieldSchema: GrabOneType
+  ) {
+    return new ArrayQuery<z.ZodEffects<GrabOneType>>({
+      query: this.query + `.${name}`,
+      schema: z.array(nullToUndefined(fieldSchema)),
     });
   }
 

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -1,7 +1,10 @@
 import { z } from "zod";
 import { grab } from "./grab";
 import type { Selection } from "./grab";
-import { nullToUndefined } from "./nullToUndefined";
+import {
+  nullToUndefined,
+  nullToUndefinedOnConditionalSelection,
+} from "./nullToUndefined";
 
 type Query = string;
 type Payload<T extends z.ZodTypeAny> = { schema: T; query: Query };
@@ -59,6 +62,8 @@ export class EntityQuery<T extends z.ZodTypeAny> extends BaseQuery<T> {
       this.schema,
       nullToUndefined(selection),
       conditionalSelections
+        ? nullToUndefinedOnConditionalSelection(conditionalSelections)
+        : conditionalSelections
     );
   }
 
@@ -136,6 +141,8 @@ export class ArrayQuery<T extends z.ZodTypeAny> extends BaseQuery<
       this.schema,
       nullToUndefined(selection),
       conditionalSelections
+        ? nullToUndefinedOnConditionalSelection(conditionalSelections)
+        : conditionalSelections
     );
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { schemas } from "./schemas";
 export type { InferType, TypeFromSelection } from "./types";
 export type { Selection } from "./grab";
 export { makeSafeQueryRunner } from "./makeSafeQueryRunner";
+export { nullToUndefined } from "./nullToUndefined";
 
 export const pipe = (filter: string): UnknownQuery => {
   return new UnknownQuery({ query: filter });

--- a/src/nullToUndefined.test.ts
+++ b/src/nullToUndefined.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { runPokemonQuery } from "../test-utils/runQuery";
+import { nullToUndefined, q } from "./index";
+import invariant from "tiny-invariant";
+
+describe("nullToUndefined", () => {
+  it("casts for single fields", async () => {
+    const { data, query } = await runPokemonQuery(
+      q("*")
+        .filter("_type == 'pokemon'")
+        .grab({
+          name: q.string(),
+          foo: nullToUndefined(q.string().optional()),
+          bar: nullToUndefined(q.string().optional().default("baz")),
+        })
+        .slice(0)
+    );
+
+    expect(query).toBe(`*[_type == 'pokemon']{name, foo, bar}[0]`);
+
+    invariant(data);
+    expect(data.name === "Bulbasaur").toBeTruthy();
+    expect(data.foo === undefined).toBeTruthy();
+    expect(data.bar === "baz").toBeTruthy();
+  });
+
+  it("casts for whole selection", async () => {
+    const { data } = await runPokemonQuery(
+      q("*")
+        .filter("_type == 'pokemon'")
+        .slice(0)
+        .grab(
+          nullToUndefined({
+            name: q.string(),
+            foo: q.string().optional(),
+            bar: q.string().optional().default("baz"),
+          })
+        )
+    );
+
+    invariant(data);
+    expect(data.name === "Bulbasaur").toBeTruthy();
+    expect(data.foo === undefined).toBeTruthy();
+    expect(data.bar === "baz").toBeTruthy();
+  });
+});

--- a/src/nullToUndefined.ts
+++ b/src/nullToUndefined.ts
@@ -1,0 +1,35 @@
+import { preprocess, z } from "zod";
+import { Selection } from "./grab";
+
+export const _nullToUndefined = <T extends z.ZodTypeAny>(schema: T) => {
+  return preprocess((arg) => (arg === null ? undefined : arg), schema);
+};
+
+export function nullToUndefined<T extends z.ZodType>(
+  schema: T
+): z.ZodEffects<T>;
+export function nullToUndefined<T extends Selection>(selection: T): T;
+export function nullToUndefined(schemaOrSelection: z.ZodType | Selection) {
+  if (schemaOrSelection instanceof z.ZodType)
+    return _nullToUndefined(schemaOrSelection);
+
+  return Object.entries(schemaOrSelection).reduce<
+    NullToUndefinedSelection<any>
+  >((acc, [key, value]) => {
+    if (value instanceof z.ZodType) acc[key] = _nullToUndefined(value);
+    else if (Array.isArray(value))
+      acc[key] = [value[0], _nullToUndefined(value[1])];
+    else acc[key] = value;
+    return acc;
+  }, {});
+}
+
+type NullToUndefinedSelection<Sel extends Selection> = {
+  [K in keyof Sel]: Sel[K] extends z.ZodType
+    ? z.ZodEffects<Sel[K]>
+    : Sel[K] extends [infer R, infer ZT]
+    ? ZT extends z.ZodType
+      ? [R, z.ZodEffects<ZT>]
+      : never
+    : Sel[K];
+};

--- a/src/nullToUndefined.ts
+++ b/src/nullToUndefined.ts
@@ -8,7 +8,9 @@ export const _nullToUndefined = <T extends z.ZodTypeAny>(schema: T) => {
 export function nullToUndefined<T extends z.ZodType>(
   schema: T
 ): z.ZodEffects<T>;
-export function nullToUndefined<T extends Selection>(selection: T): T;
+export function nullToUndefined<T extends Selection>(
+  selection: T
+): NullToUndefinedSelection<T>;
 export function nullToUndefined(schemaOrSelection: z.ZodType | Selection) {
   if (schemaOrSelection instanceof z.ZodType)
     return _nullToUndefined(schemaOrSelection);
@@ -20,6 +22,25 @@ export function nullToUndefined(schemaOrSelection: z.ZodType | Selection) {
     else if (Array.isArray(value))
       acc[key] = [value[0], _nullToUndefined(value[1])];
     else acc[key] = value;
+    return acc;
+  }, {});
+}
+
+export function nullToUndefinedOnConditionalSelection(
+  conditionalSelection?: undefined
+): undefined;
+export function nullToUndefinedOnConditionalSelection<
+  T extends Record<string, Selection>
+>(conditionalSelection: T): { [K in keyof T]: NullToUndefinedSelection<T[K]> };
+export function nullToUndefinedOnConditionalSelection(
+  conditionalSelection?: Record<string, Selection> | undefined
+) {
+  if (!conditionalSelection) return conditionalSelection;
+
+  return Object.entries(conditionalSelection).reduce<
+    Record<string, NullToUndefinedSelection<any>>
+  >((acc, [key, value]) => {
+    acc[key] = nullToUndefined(value);
     return acc;
   }, {});
 }


### PR DESCRIPTION
Sanity/GROQ return `null` values for missing values. This becomes annoying to deal with with `groqd` because you end up littering a lot of `.nullable()`s around, but you can't do `.default()` chained on a nullable. This PR adds some helpers to preprocess `null` values to `undefined` so that if a value is missing, we can assume it's `undefined` which allows for more consistent chaining and ability to do things like

```ts
q().grab$({
  nope: q.optional().default("not there")
})
```

and then `data["nope"]` is of type `string`.

---

**Example showing groq returning `null` for a missing value.**

![image](https://user-images.githubusercontent.com/12721310/220947394-c3640b2a-57bc-492e-b559-653850bf146b.png)
