### PR TITLE
Bug: Conditional Selection Type

### DIFF
--- a/src/builder.test.ts
+++ b/src/builder.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { q } from "./index";
+import { q, InferType } from "./index";
 import { z } from "zod";
 import { runPokemonQuery, runUserQuery } from "../test-utils/runQuery";
 import invariant from "tiny-invariant";
@@ -83,26 +83,26 @@ describe("ArrayResult.grab/UnknownResult.grab/EntityResult.grab", () => {
   });
 
   it("can handle conditional selections", async () => {
-    const { data, query } = await runPokemonQuery(
-      q("*")
-        .filter("_type == 'pokemon'")
-        .slice(0, 3)
-        .grab(
-          {
-            _id: z.string(),
+    const pokemonQuery = q("*")
+      .filter("_type == 'pokemon'")
+      .slice(0, 3)
+      .grab(
+        {
+          _id: z.string(),
+        },
+        {
+          "name == 'Charmander'": {
+            name: q.literal("Charmander"),
+            hp: ["base.HP", q.number()],
           },
-          {
-            "name == 'Charmander'": {
-              name: q.literal("Charmander"),
-              hp: ["base.HP", q.number()],
-            },
-            "name == 'Bulbasaur'": {
-              name: q.literal("Bulbasaur"),
-              attack: ["base.Attack", q.number()],
-            },
-          }
-        )
-    );
+          "name == 'Bulbasaur'": {
+            name: q.literal("Bulbasaur"),
+            attack: ["base.Attack", q.number()],
+          },
+        }
+      );
+
+    const { data, query } = await runPokemonQuery(pokemonQuery);
 
     expect(query).toBe(
       `*[_type == 'pokemon'][0..3]{_id, ...select(name == 'Charmander' => { name, "hp": base.HP }, name == 'Bulbasaur' => { name, "attack": base.Attack })}`
@@ -117,11 +117,14 @@ describe("ArrayResult.grab/UnknownResult.grab/EntityResult.grab", () => {
     expect(data[1]).toEqual({ _id: "pokemon.2" });
     expect(data[3]).toEqual({ _id: "pokemon.4", name: "Charmander", hp: 39 });
 
+    type pokemonName = InferType<typeof pokemonQuery>[number]["name"];
+
     for (const dat of data) {
       if ("name" in dat && dat.name === "Charmander") {
-        expect(dat.name === "Charmander").toBeTruthy();
+        const name: pokemonName = dat.name;
+        expect(name === "Charmander").toBeTruthy();
         // @ts-expect-error Expect error here, TS should infer type
-        expect(dat.name === "Bulbasaur").toBeFalsy();
+        expect(name === "Bulbasaur").toBeFalsy();
         // @ts-expect-error Attack field isn't present on Charmander document
         expect(dat.attack).toBeUndefined();
         expect(dat.hp).toBe(39);

--- a/src/grab.ts
+++ b/src/grab.ts
@@ -14,14 +14,9 @@ export const grab = <
 ) => {
   type AllSelection = undefined extends CondSelections
     ? FromSelection<S>
-    : z.ZodUnion<
-        [
-          ValueOf<{
-            [K in keyof CondSelections]: FromSelection<S & CondSelections[K]>;
-          }>,
-          FromSelection<S>
-        ]
-      >;
+    : ValueOf<{
+        [K in keyof CondSelections]: FromSelection<S & CondSelections[K]>;
+      }>;
 
   type NewType = T extends z.ZodArray<any>
     ? ArrayQuery<AllSelection>


### PR DESCRIPTION
# Summary
Ran into some type issues using conditional selections. This PR:
- Updates the conditional selection type inside `grab`
- adds a test case to the `builder` spec

## Technical Details
```ts
import { q, InferType } from 'groqd';

const pokemonQuery = q("*")
  .filter("_type == 'pokemon'")
  .grab(
    {
      _id: z.string(),
    },
    {
      "name == 'Charmander'": {
        name: q.literal("Charmander"),
      },
      "name == 'Bulbasaur'": {
        name: q.literal("Bulbasaur"),
      },
    }
  );
  
// Before

type Pokemon = InferType<typeof query>
//^? { _id: string } | { _id: string; name: "Charmander" } | { _id: string; name: "Bulbasaur"}

type PokemonName = Pokemon[number]["name"]
// ts error: Property 'name' does not exist on type { _id: string } | { _id: string; name: "Charmander" } | { _id: string; name: "Bulbasaur"}


// After

type Pokemon = InferType<typeof query>
//^? { _id: string; name: "Charmander" } | { _id: string; name: "Bulbasaur"}

type PokemonName = Pokemon[number]["name"]
//^? "Charmander" | "Bulbasaur"
```