### PR TITLE
Top Level Select Method

### DIFF
--- a/.changeset/happy-toes-impress.md
+++ b/.changeset/happy-toes-impress.md
@@ -2,5 +2,5 @@
 "groqd": minor
 ---
 
-- `q.select` schema helper for stronger union types and default conditions
-- `ArrayQuery.select` & `EntityQuery.select` helpers to spread select functions in a block scope 
+- `q.select` schema helper for stronger union types and default conditions ([#82](https://github.com/FormidableLabs/groqd/pull/82))
+- `ArrayQuery.select` & `EntityQuery.select` helpers to spread select functions in a block scope ([#82](https://github.com/FormidableLabs/groqd/pull/82))

--- a/.changeset/happy-toes-impress.md
+++ b/.changeset/happy-toes-impress.md
@@ -1,0 +1,6 @@
+---
+"groqd": minor
+---
+
+- `q.select` schema helper for stronger union types and default conditions
+- `ArrayQuery.select` & `EntityQuery.select` helpers to spread select functions in a block scope 

--- a/src/baseQuery.ts
+++ b/src/baseQuery.ts
@@ -1,0 +1,33 @@
+import { z } from "zod";
+
+export type Query = string;
+export type Payload<T extends z.ZodTypeAny> = { schema: T; query: Query };
+
+export class BaseQuery<T extends z.ZodTypeAny> {
+  query: string;
+  schema: T;
+
+  constructor({ query, schema }: Payload<T>) {
+    this.query = query;
+    this.schema = schema;
+  }
+
+  public value(): Payload<T> {
+    return { schema: this.schema, query: this.query };
+  }
+
+  nullable() {
+    return new NullableBaseQuery({
+      query: this.query,
+      schema: this.schema.nullable(),
+    });
+  }
+}
+
+export class NullableBaseQuery<T extends z.ZodTypeAny> extends BaseQuery<
+  z.ZodNullable<T>
+> {
+  constructor({ schema, query }: Payload<T>) {
+    super({ schema: schema.nullable(), query });
+  }
+}

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -15,8 +15,6 @@ import {
 } from "./nullToUndefined";
 import { Payload, BaseQuery } from "./baseQuery";
 
-export { Payload, BaseQuery } from "./baseQuery";
-
 /**
  * Single Entity
  */

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -54,13 +54,11 @@ export class EntityQuery<T extends z.ZodTypeAny> extends BaseQuery<T> {
     super(payload);
   }
 
-  __experimental_select<Conditions extends ConditionRecord>(
+  select<Conditions extends ConditionRecord>(
     s: Conditions
   ): EntityQuery<Spread<SelectSchemaType<Conditions>>>;
-  __experimental_select<S extends ZodUnionAny>(
-    s: BaseQuery<S>
-  ): EntityQuery<Spread<S>>;
-  __experimental_select<Conditions extends ConditionRecord>(
+  select<S extends ZodUnionAny>(s: BaseQuery<S>): EntityQuery<Spread<S>>;
+  select<Conditions extends ConditionRecord>(
     s: Conditions
   ): EntityQuery<Spread<SelectSchemaType<Conditions>>> {
     const _select = extendsBaseQuery(s) ? s : select(s);
@@ -145,13 +143,11 @@ export class ArrayQuery<T extends z.ZodTypeAny> extends BaseQuery<
     super(payload);
   }
 
-  __experimental_select<Conditions extends ConditionRecord>(
+  select<Conditions extends ConditionRecord>(
     s: Conditions
   ): ArrayQuery<Spread<SelectSchemaType<Conditions>>>;
-  __experimental_select<S extends ZodUnionAny>(
-    s: BaseQuery<S>
-  ): ArrayQuery<Spread<S>>;
-  __experimental_select<Conditions extends ConditionRecord>(
+  select<S extends ZodUnionAny>(s: BaseQuery<S>): ArrayQuery<Spread<S>>;
+  select<Conditions extends ConditionRecord>(
     s: Conditions
   ): ArrayQuery<Spread<SelectSchemaType<Conditions>>> {
     const _select = extendsBaseQuery(s) ? s : select(s);

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { grab } from "./grab";
-import { select } from "./select";
+import { select, spreadUnionSchema } from "./select";
 import type {
   ConditionRecord,
   ZodUnionAny,
@@ -36,7 +36,7 @@ export class EntityQuery<T extends z.ZodTypeAny> extends BaseQuery<T> {
 
     return new EntityQuery<Spread<SelectSchemaType<Conditions>>>({
       query: this.query + `{...${_select.query}}`,
-      schema: _select.schema,
+      schema: spreadUnionSchema(_select.schema),
     });
   }
 
@@ -125,7 +125,7 @@ export class ArrayQuery<T extends z.ZodTypeAny> extends BaseQuery<
 
     return new ArrayQuery<Spread<SelectSchemaType<Conditions>>>({
       query: this.query + `{...${_select.query}}`,
-      schema: z.array(_select.schema),
+      schema: z.array(spreadUnionSchema(_select.schema)),
     });
   }
 

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -3,8 +3,9 @@ import { grab } from "./grab";
 import { select } from "./select";
 import type {
   ConditionRecord,
-  ConditionSchema,
+  ZodUnionAny,
   SelectSchemaType,
+  Spread,
 } from "./select";
 import type { Selection } from "./types";
 import { extendsBaseQuery } from "./typeGuards";
@@ -53,16 +54,18 @@ export class EntityQuery<T extends z.ZodTypeAny> extends BaseQuery<T> {
     super(payload);
   }
 
-  __select<Conditions extends ConditionRecord>(
+  __experimental_select<Conditions extends ConditionRecord>(
     s: Conditions
-  ): EntityQuery<SelectSchemaType<Conditions>>;
-  __select<S extends z.ZodType>(s: BaseQuery<S>): EntityQuery<S>;
-  __select<Conditions extends ConditionRecord>(
+  ): EntityQuery<Spread<SelectSchemaType<Conditions>>>;
+  __experimental_select<S extends ZodUnionAny>(
+    s: BaseQuery<S>
+  ): EntityQuery<Spread<S>>;
+  __experimental_select<Conditions extends ConditionRecord>(
     s: Conditions
-  ): EntityQuery<SelectSchemaType<Conditions>> {
+  ): EntityQuery<Spread<SelectSchemaType<Conditions>>> {
     const _select = extendsBaseQuery(s) ? s : select(s);
 
-    return new EntityQuery<ConditionSchema<Conditions[string]>>({
+    return new EntityQuery<Spread<SelectSchemaType<Conditions>>>({
       query: this.query + `{...${_select.query}}`,
       schema: _select.schema,
     });
@@ -142,16 +145,18 @@ export class ArrayQuery<T extends z.ZodTypeAny> extends BaseQuery<
     super(payload);
   }
 
-  __select<Conditions extends ConditionRecord>(
+  __experimental_select<Conditions extends ConditionRecord>(
     s: Conditions
-  ): ArrayQuery<SelectSchemaType<Conditions>>;
-  __select<S extends z.ZodType>(s: BaseQuery<S>): ArrayQuery<S>;
-  __select<Conditions extends ConditionRecord>(
+  ): ArrayQuery<Spread<SelectSchemaType<Conditions>>>;
+  __experimental_select<S extends ZodUnionAny>(
+    s: BaseQuery<S>
+  ): ArrayQuery<Spread<S>>;
+  __experimental_select<Conditions extends ConditionRecord>(
     s: Conditions
-  ): ArrayQuery<SelectSchemaType<Conditions>> {
+  ): ArrayQuery<Spread<SelectSchemaType<Conditions>>> {
     const _select = extendsBaseQuery(s) ? s : select(s);
 
-    return new ArrayQuery<ConditionSchema<Conditions[string]>>({
+    return new ArrayQuery<Spread<SelectSchemaType<Conditions>>>({
       query: this.query + `{...${_select.query}}`,
       schema: _select.schema,
     });

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { grab } from "./grab";
-import type { Selection } from "./grab";
+import type { Selection } from "./types";
 import {
   nullToUndefined,
   nullToUndefinedOnConditionalSelection,

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -13,38 +13,9 @@ import {
   nullToUndefined,
   nullToUndefinedOnConditionalSelection,
 } from "./nullToUndefined";
+import { Payload, BaseQuery } from "./baseQuery";
 
-type Query = string;
-type Payload<T extends z.ZodTypeAny> = { schema: T; query: Query };
-
-export class BaseQuery<T extends z.ZodTypeAny> {
-  query: string;
-  schema: T;
-
-  constructor({ query, schema }: Payload<T>) {
-    this.query = query;
-    this.schema = schema;
-  }
-
-  public value(): Payload<T> {
-    return { schema: this.schema, query: this.query };
-  }
-
-  nullable() {
-    return new NullableBaseQuery({
-      query: this.query,
-      schema: this.schema.nullable(),
-    });
-  }
-}
-
-export class NullableBaseQuery<T extends z.ZodTypeAny> extends BaseQuery<
-  z.ZodNullable<T>
-> {
-  constructor({ schema, query }: Payload<T>) {
-    super({ schema: schema.nullable(), query });
-  }
-}
+export { Payload, BaseQuery } from "./baseQuery";
 
 /**
  * Single Entity
@@ -154,7 +125,7 @@ export class ArrayQuery<T extends z.ZodTypeAny> extends BaseQuery<
 
     return new ArrayQuery<Spread<SelectSchemaType<Conditions>>>({
       query: this.query + `{...${_select.query}}`,
-      schema: _select.schema,
+      schema: z.array(_select.schema),
     });
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,10 +4,7 @@ import { sanityImage } from "./sanityImage";
 import { schemas } from "./schemas";
 import { select } from "./select";
 
-import type { InferType, TypeFromSelection } from "./types";
-
-export type { InferType, TypeFromSelection } from "./types";
-export type { Selection } from "./grab";
+export type { InferType, TypeFromSelection, Selection } from "./types";
 export { makeSafeQueryRunner } from "./makeSafeQueryRunner";
 export { nullToUndefined } from "./nullToUndefined";
 
@@ -16,7 +13,7 @@ export const pipe = (filter: string): UnknownQuery => {
 };
 
 pipe.sanityImage = sanityImage;
-pipe.select = select;
+pipe.__select = select;
 
 // Add schemas
 Object.assign(pipe, schemas);
@@ -24,29 +21,6 @@ type Pipe = typeof pipe & typeof schemas;
 
 // Our main export is the pipe, renamed as q
 export const q = pipe as Pipe;
-
-const foo = q.select({
-  "booger > 5": ["hello", q.literal("hello")],
-  "booger > 10": {
-    bar: q.literal("bar"),
-  },
-  "booger > 15": {
-    bar: q.string(),
-    id: q.string(),
-  },
-  default: {
-    form: q("form").deref().grab({
-      boop: q.number(),
-    }),
-  },
-});
-
-const query = q("*").grab({
-  foo,
-});
-
-type Query = InferType<typeof query>;
-type Foo = InferType<typeof foo>;
 
 /**
  * Export zod for convenience

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ export const pipe = (filter: string): UnknownQuery => {
 };
 
 pipe.sanityImage = sanityImage;
-pipe.__select = select;
+pipe.__experimental_select = select;
 
 // Add schemas
 Object.assign(pipe, schemas);

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ export const pipe = (filter: string): UnknownQuery => {
 };
 
 pipe.sanityImage = sanityImage;
-pipe.__experimental_select = select;
+pipe.select = select;
 
 // Add schemas
 Object.assign(pipe, schemas);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,9 @@ import { z } from "zod";
 import { UnknownQuery } from "./builder";
 import { sanityImage } from "./sanityImage";
 import { schemas } from "./schemas";
+import { select } from "./select";
+
+import type { InferType, TypeFromSelection } from "./types";
 
 export type { InferType, TypeFromSelection } from "./types";
 export type { Selection } from "./grab";
@@ -13,6 +16,7 @@ export const pipe = (filter: string): UnknownQuery => {
 };
 
 pipe.sanityImage = sanityImage;
+pipe.select = select;
 
 // Add schemas
 Object.assign(pipe, schemas);
@@ -20,6 +24,29 @@ type Pipe = typeof pipe & typeof schemas;
 
 // Our main export is the pipe, renamed as q
 export const q = pipe as Pipe;
+
+const foo = q.select({
+  "booger > 5": ["hello", q.literal("hello")],
+  "booger > 10": {
+    bar: q.literal("bar"),
+  },
+  "booger > 15": {
+    bar: q.string(),
+    id: q.string(),
+  },
+  default: {
+    form: q("form").deref().grab({
+      boop: q.number(),
+    }),
+  },
+});
+
+const query = q("*").grab({
+  foo,
+});
+
+type Query = InferType<typeof query>;
+type Foo = InferType<typeof foo>;
 
 /**
  * Export zod for convenience

--- a/src/makeSafeQueryRunner.ts
+++ b/src/makeSafeQueryRunner.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { BaseQuery } from "./builder";
+import { BaseQuery } from "./baseQuery";
 
 /**
  * Utility to create a "query runner" that consumes the result of the `q` function.

--- a/src/nullToUndefined.ts
+++ b/src/nullToUndefined.ts
@@ -1,5 +1,5 @@
 import { preprocess, z } from "zod";
-import { Selection } from "./grab";
+import { Selection } from "./types";
 
 export const _nullToUndefined = <T extends z.ZodTypeAny>(schema: T) => {
   return preprocess((arg) => (arg === null ? undefined : arg), schema);

--- a/src/sanityImage.ts
+++ b/src/sanityImage.ts
@@ -1,5 +1,5 @@
 import { ArrayQuery, EntityQuery, UnknownQuery } from "./builder";
-import type { FromSelection, Selection } from "./grab";
+import type { FromSelection, Selection } from "./types";
 import { schemas } from "./schemas";
 import { ListIncludes } from "./types";
 

--- a/src/select.test.ts
+++ b/src/select.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, expectTypeOf, it } from "vitest";
 
 describe("q.select()", () => {
   it("creates query from {condition: selection} composition", () => {
-    const { query, schema } = q.__experimental_select({
+    const { query, schema } = q.select({
       "foo > 2": {
         bar: z.boolean(),
       },
@@ -20,7 +20,7 @@ describe("q.select()", () => {
   });
 
   it("creates query from {condition: q()} composition", () => {
-    const { query, schema } = q.__experimental_select({
+    const { query, schema } = q.select({
       "foo > 2": q("bar").grab({
         bar: z.boolean(),
       }),
@@ -36,7 +36,7 @@ describe("q.select()", () => {
   });
 
   it("creates query from {condition: [name, schema]} composition", () => {
-    const { query, schema } = q.__experimental_select({
+    const { query, schema } = q.select({
       "foo > 2": ["bar", q.boolean()],
       default: {
         baz: z.string(),
@@ -50,7 +50,7 @@ describe("q.select()", () => {
   });
 
   it("makes schema nullable when default condition omitted", () => {
-    const { query, schema } = q.__experimental_select({
+    const { query, schema } = q.select({
       "foo > 2": {
         bar: z.boolean(),
       },
@@ -63,7 +63,7 @@ describe("q.select()", () => {
   });
 
   it("handles nested selects properly", () => {
-    const nestedSelect = q.__experimental_select({
+    const nestedSelect = q.select({
       'bar == "thing"': {
         b: q.string(),
       },
@@ -72,7 +72,7 @@ describe("q.select()", () => {
       },
     });
 
-    const { query, schema } = q.__experimental_select({
+    const { query, schema } = q.select({
       "foo > 2": nestedSelect,
       default: {
         baz: z.string(),
@@ -91,7 +91,7 @@ describe("q.select()", () => {
 describe("EntityQuery.select()", () => {
   describe("with standalone select input", () => {
     it("updates query and handles nested object types", () => {
-      const standaloneSelect = q.__experimental_select({
+      const standaloneSelect = q.select({
         "foo > 2": {
           bar: z.boolean(),
         },
@@ -99,7 +99,7 @@ describe("EntityQuery.select()", () => {
           baz: z.string(),
         },
       });
-      const entityQuery = q("foo").__experimental_select(standaloneSelect);
+      const entityQuery = q("foo").select(standaloneSelect);
 
       expect(entityQuery.query).toBe(
         "foo{...select(foo > 2 => { bar }, { baz })}"
@@ -110,12 +110,12 @@ describe("EntityQuery.select()", () => {
     });
 
     it("converts no default condition to empty object", () => {
-      const standaloneSelect = q.__experimental_select({
+      const standaloneSelect = q.select({
         "foo > 2": {
           bar: z.boolean(),
         },
       });
-      const entityQuery = q("foo").__experimental_select(standaloneSelect);
+      const entityQuery = q("foo").select(standaloneSelect);
 
       expect(entityQuery.query).toBe("foo{...select(foo > 2 => { bar })}");
       expectTypeOf({} as z.infer<typeof entityQuery.schema>).toEqualTypeOf<
@@ -124,13 +124,13 @@ describe("EntityQuery.select()", () => {
     });
 
     it("converts primitives to empty object", () => {
-      const standaloneSelect = q.__experimental_select({
+      const standaloneSelect = q.select({
         "foo > 2": ["bar", z.boolean()],
         default: {
           baz: z.string(),
         },
       });
-      const entityQuery = q("foo").__experimental_select(standaloneSelect);
+      const entityQuery = q("foo").select(standaloneSelect);
 
       expect(entityQuery.query).toBe("foo{...select(foo > 2 => bar, { baz })}");
       expectTypeOf({} as z.infer<typeof entityQuery.schema>).toEqualTypeOf<
@@ -139,20 +139,20 @@ describe("EntityQuery.select()", () => {
     });
 
     it("handles nested union types properly", () => {
-      const nestedSelect = q.__experimental_select({
+      const nestedSelect = q.select({
         "foo == 3": ["a", q.string()],
         default: {
           b: q.boolean(),
         },
       });
 
-      const standaloneSelect = q.__experimental_select({
+      const standaloneSelect = q.select({
         "foo > 2": nestedSelect,
         default: {
           baz: z.string(),
         },
       });
-      const entityQuery = q("foo").__experimental_select(standaloneSelect);
+      const entityQuery = q("foo").select(standaloneSelect);
 
       expect(entityQuery.query).toBe(
         "foo{...select(foo > 2 => select(foo == 3 => a, { b }), { baz })}"
@@ -165,7 +165,7 @@ describe("EntityQuery.select()", () => {
 
   describe("with {condition: Selection} input", () => {
     it("updates query and handles nested object types", () => {
-      const entityQuery = q("foo").__experimental_select({
+      const entityQuery = q("foo").select({
         "foo > 2": {
           bar: z.boolean(),
         },
@@ -186,7 +186,7 @@ describe("EntityQuery.select()", () => {
 
 describe("ArrayQuery.select()", () => {
   it("handles standalone select input", () => {
-    const standaloneSelect = q.__experimental_select({
+    const standaloneSelect = q.select({
       "foo > 2": {
         bar: z.boolean(),
       },
@@ -194,7 +194,7 @@ describe("ArrayQuery.select()", () => {
         baz: z.string(),
       },
     });
-    const query = q("*").filter().__experimental_select(standaloneSelect);
+    const query = q("*").filter().select(standaloneSelect);
 
     expect(query.query).toBe("*[]{...select(foo > 2 => { bar }, { baz })}");
     expectTypeOf({} as z.infer<typeof query.schema>).toEqualTypeOf<
@@ -205,7 +205,7 @@ describe("ArrayQuery.select()", () => {
   it("handles {condition: Selection} input", () => {
     const query = q("*")
       .filter()
-      .__experimental_select({
+      .select({
         "foo > 2": {
           bar: z.boolean(),
         },

--- a/src/select.test.ts
+++ b/src/select.test.ts
@@ -1,0 +1,222 @@
+import { q } from "./index";
+import { z } from "zod";
+import { describe, expect, expectTypeOf, it } from "vitest";
+
+describe("q.select()", () => {
+  it("creates query from {condition: selection} composition", () => {
+    const { query, schema } = q.__experimental_select({
+      "foo > 2": {
+        bar: z.boolean(),
+      },
+      default: {
+        baz: z.string(),
+      },
+    });
+
+    expect(query).toBe("select(foo > 2 => { bar }, { baz })");
+    expectTypeOf({} as z.infer<typeof schema>).toEqualTypeOf<
+      { bar: boolean } | { baz: string }
+    >();
+  });
+
+  it("creates query from {condition: q()} composition", () => {
+    const { query, schema } = q.__experimental_select({
+      "foo > 2": q("bar").grab({
+        bar: z.boolean(),
+      }),
+      default: {
+        baz: z.string(),
+      },
+    });
+
+    expect(query).toBe("select(foo > 2 => bar{bar}, { baz })");
+    expectTypeOf({} as z.infer<typeof schema>).toEqualTypeOf<
+      { bar: boolean } | { baz: string }
+    >();
+  });
+
+  it("creates query from {condition: [name, schema]} composition", () => {
+    const { query, schema } = q.__experimental_select({
+      "foo > 2": ["bar", q.boolean()],
+      default: {
+        baz: z.string(),
+      },
+    });
+
+    expect(query).toBe("select(foo > 2 => bar, { baz })");
+    expectTypeOf({} as z.infer<typeof schema>).toEqualTypeOf<
+      boolean | { baz: string }
+    >();
+  });
+
+  it("makes schema nullable when default condition omitted", () => {
+    const { query, schema } = q.__experimental_select({
+      "foo > 2": {
+        bar: z.boolean(),
+      },
+    });
+
+    expect(query).toBe("select(foo > 2 => { bar })");
+    expectTypeOf({} as z.infer<typeof schema>).toEqualTypeOf<{
+      bar: boolean;
+    } | null>();
+  });
+
+  it("handles nested selects properly", () => {
+    const nestedSelect = q.__experimental_select({
+      'bar == "thing"': {
+        b: q.string(),
+      },
+      default: {
+        c: z.string(),
+      },
+    });
+
+    const { query, schema } = q.__experimental_select({
+      "foo > 2": nestedSelect,
+      default: {
+        baz: z.string(),
+      },
+    });
+
+    expect(query).toBe(
+      'select(foo > 2 => select(bar == "thing" => { b }, { c }), { baz })'
+    );
+    expectTypeOf({} as z.infer<typeof schema>).toEqualTypeOf<
+      { b: string } | { c: string } | { baz: string }
+    >();
+  });
+});
+
+describe("EntityQuery.select()", () => {
+  describe("with standalone select input", () => {
+    it("updates query and handles nested object types", () => {
+      const standaloneSelect = q.__experimental_select({
+        "foo > 2": {
+          bar: z.boolean(),
+        },
+        default: {
+          baz: z.string(),
+        },
+      });
+      const entityQuery = q("foo").__experimental_select(standaloneSelect);
+
+      expect(entityQuery.query).toBe(
+        "foo{...select(foo > 2 => { bar }, { baz })}"
+      );
+      expectTypeOf({} as z.infer<typeof entityQuery.schema>).toEqualTypeOf<
+        { bar: boolean } | { baz: string }
+      >();
+    });
+
+    it("converts no default condition to empty object", () => {
+      const standaloneSelect = q.__experimental_select({
+        "foo > 2": {
+          bar: z.boolean(),
+        },
+      });
+      const entityQuery = q("foo").__experimental_select(standaloneSelect);
+
+      expect(entityQuery.query).toBe("foo{...select(foo > 2 => { bar })}");
+      expectTypeOf({} as z.infer<typeof entityQuery.schema>).toEqualTypeOf<
+        { bar: boolean } | {}
+      >();
+    });
+
+    it("converts primitives to empty object", () => {
+      const standaloneSelect = q.__experimental_select({
+        "foo > 2": ["bar", z.boolean()],
+        default: {
+          baz: z.string(),
+        },
+      });
+      const entityQuery = q("foo").__experimental_select(standaloneSelect);
+
+      expect(entityQuery.query).toBe("foo{...select(foo > 2 => bar, { baz })}");
+      expectTypeOf({} as z.infer<typeof entityQuery.schema>).toEqualTypeOf<
+        {} | { baz: string }
+      >();
+    });
+
+    it("handles nested union types properly", () => {
+      const nestedSelect = q.__experimental_select({
+        "foo == 3": ["a", q.string()],
+        default: {
+          b: q.boolean(),
+        },
+      });
+
+      const standaloneSelect = q.__experimental_select({
+        "foo > 2": nestedSelect,
+        default: {
+          baz: z.string(),
+        },
+      });
+      const entityQuery = q("foo").__experimental_select(standaloneSelect);
+
+      expect(entityQuery.query).toBe(
+        "foo{...select(foo > 2 => select(foo == 3 => a, { b }), { baz })}"
+      );
+      expectTypeOf({} as z.infer<typeof entityQuery.schema>).toEqualTypeOf<
+        {} | { b: boolean } | { baz: string }
+      >();
+    });
+  });
+
+  describe("with {condition: Selection} input", () => {
+    it("updates query and handles nested object types", () => {
+      const entityQuery = q("foo").__experimental_select({
+        "foo > 2": {
+          bar: z.boolean(),
+        },
+        default: {
+          baz: z.string(),
+        },
+      });
+
+      expect(entityQuery.query).toBe(
+        "foo{...select(foo > 2 => { bar }, { baz })}"
+      );
+      expectTypeOf({} as z.infer<typeof entityQuery.schema>).toEqualTypeOf<
+        { bar: boolean } | { baz: string }
+      >();
+    });
+  });
+});
+
+describe("ArrayQuery.select()", () => {
+  it("handles standalone select input", () => {
+    const standaloneSelect = q.__experimental_select({
+      "foo > 2": {
+        bar: z.boolean(),
+      },
+      default: {
+        baz: z.string(),
+      },
+    });
+    const query = q("*").filter().__experimental_select(standaloneSelect);
+
+    expect(query.query).toBe("*[]{...select(foo > 2 => { bar }, { baz })}");
+    expectTypeOf({} as z.infer<typeof query.schema>).toEqualTypeOf<
+      ({ bar: boolean } | { baz: string })[]
+    >();
+  });
+
+  it("handles {condition: Selection} input", () => {
+    const query = q("*")
+      .filter()
+      .__experimental_select({
+        "foo > 2": {
+          bar: z.boolean(),
+        },
+        default: {
+          baz: z.string(),
+        },
+      });
+
+    expect(query.query).toBe("*[]{...select(foo > 2 => { bar }, { baz })}");
+    expectTypeOf({} as z.infer<typeof query.schema>).toEqualTypeOf<
+      ({ bar: boolean } | { baz: string })[]
+    >();
+  });
+});

--- a/src/select.ts
+++ b/src/select.ts
@@ -139,7 +139,7 @@ export function spreadUnionSchema<Z extends z.ZodType>(
       // option is a zod union
       // @ts-expect-error option Inferring nested union types within zod union outside the casted
       // return type is unreasonable. It is fine to ignore ts here because the casted
-      // the return type at the end of this function is correct
+      // return type at the end of this function is correct
       if ("options" in option) return spreadUnionSchema(option);
 
       // option is a zod primitive

--- a/src/select.ts
+++ b/src/select.ts
@@ -108,6 +108,10 @@ type EmptyZodObject = typeof emptyZodRecord;
 type ZodObjectAny = z.ZodObject<Record<string, any>>;
 export type ZodUnionAny = z.ZodUnion<readonly [z.ZodType, ...z.ZodType[]]>;
 
+// go through each type in a zod union
+// if it's an object, resolve to that object
+// if it's a union, apply the same logic to each type in that union
+// if it's a primitive, resolve to an empty object
 export type Spread<ZU extends ZodUnionAny> = ZU extends z.ZodUnion<
   infer T extends readonly [z.ZodType, ...z.ZodType[]]
 >

--- a/src/select.ts
+++ b/src/select.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { BaseQuery } from "./builder";
+import { BaseQuery } from "./baseQuery";
 import {
   getProjectionEntriesFromSelection,
   getSchemaFromSelection,

--- a/src/select.ts
+++ b/src/select.ts
@@ -7,12 +7,7 @@ import {
 import { extendsBaseQuery, isQuerySchemaTuple } from "./typeGuards";
 import type { FromSelection, Selection } from "./types";
 
-export const select = <
-  Conditions extends Record<
-    string,
-    Selection | BaseQuery<any> | [string, z.ZodType]
-  >
->(
+export const select = <Conditions extends ConditionRecord>(
   conditionalSelections: Conditions
 ) => {
   const getProjection = (
@@ -77,12 +72,21 @@ export const select = <
  * Misc util
  */
 
-type ConditionSchema<
-  Condition extends Selection | BaseQuery<any> | [string, z.ZodType]
-> = Condition extends Selection
-  ? FromSelection<Condition>
-  : Condition extends BaseQuery<any>
-  ? Condition["schema"]
-  : Condition extends [string, z.ZodType]
-  ? Condition[1]
-  : never;
+export type ConditionValue = Selection | BaseQuery<any> | [string, z.ZodType];
+export type ConditionRecord = Record<string, ConditionValue>;
+export type ConditionSchema<Condition extends ConditionValue> =
+  Condition extends Selection
+    ? FromSelection<Condition>
+    : Condition extends BaseQuery<any>
+    ? Condition["schema"]
+    : Condition extends [string, z.ZodType]
+    ? Condition[1]
+    : never;
+
+export type SelectSchemaType<Conditions extends ConditionRecord> = z.ZodUnion<
+  [
+    ConditionSchema<Conditions[keyof Conditions]>,
+    ConditionSchema<Conditions[keyof Conditions]>,
+    ...ConditionSchema<Conditions[keyof Conditions]>[]
+  ]
+>;

--- a/src/select.ts
+++ b/src/select.ts
@@ -136,8 +136,8 @@ export function spreadUnionSchema<Z extends z.ZodType>(
       // option is a zod object
       if ("shape" in option) return option;
 
-      // @ts-expect-error option is a zod union
-      // Inferring nested union types within zod union outside the casted
+      // option is a zod union
+      // @ts-expect-error option Inferring nested union types within zod union outside the casted
       // return type is unreasonable. It is fine to ignore ts here because the casted
       // the return type at the end of this function is correct
       if ("options" in option) return spreadUnionSchema(option);

--- a/src/select.ts
+++ b/src/select.ts
@@ -1,0 +1,138 @@
+import { z } from "zod";
+import { BaseQuery } from "./builder";
+
+export const select = <
+  Conditions extends Record<
+    string,
+    Selection | BaseQuery<any> | [string, z.ZodType]
+  >
+>(
+  conditionalSelections: Conditions
+) => {
+  // Recursively define projections to pick up nested conditionals
+  const getProjectionEntries = (sel: Selection) =>
+    Object.entries(sel).reduce<string[]>((acc, [key, val]) => {
+      let toPush = "";
+      if (val instanceof BaseQuery) {
+        toPush = `"${key}": ${val.query}`;
+      } else if (Array.isArray(val)) {
+        toPush = `"${key}": ${val[0]}`;
+      } else {
+        toPush = key;
+      }
+
+      if (toPush) acc.push(toPush);
+
+      return acc;
+    }, []);
+
+  const getProjection = (
+    v: Selection | BaseQuery<any> | [string, z.ZodType]
+  ) => {
+    if (v instanceof BaseQuery) {
+      return v.query;
+    }
+
+    if (Array.isArray(v)) {
+      return v[0];
+    }
+
+    return `{ ${getProjectionEntries(v).join(", ")} }`;
+  };
+
+  const { default: defaultSelection, ...selections } = conditionalSelections;
+
+  const condProjections = Object.entries(selections).reduce<string[]>(
+    (acc, [condition, val]) => {
+      acc.push(`${condition} => ${getProjection(val)}`);
+      return acc;
+    },
+    []
+  );
+
+  if (defaultSelection) {
+    condProjections.push(getProjection(defaultSelection));
+  }
+
+  const query = `select(${condProjections.join(", ")})`;
+
+  const newSchema = (() => {
+    const parseSelection = (selection: Selection) =>
+      Object.entries(selection).reduce<z.ZodRawShape>((acc, [key, value]) => {
+        if (value instanceof BaseQuery) {
+          acc[key] = value.schema;
+        } else if (Array.isArray(value)) {
+          acc[key] = value[1];
+        } else if (value instanceof z.ZodType) {
+          acc[key] = value;
+        }
+        return acc;
+      }, {});
+
+    const toSchemaInput = (
+      v: Conditions[keyof Conditions]
+    ): ConditionSchema<Conditions[keyof Conditions]> => {
+      if (extendsBaseQuery(v)) return v.schema;
+
+      if (isQuerySchemaTuple(v)) {
+        return v[1] as ConditionSchema<Conditions[keyof Conditions]>;
+      }
+
+      return z.object(parseSelection(v as Selection)) as ConditionSchema<
+        Conditions[keyof Conditions]
+      >;
+    };
+
+    const unionEls = (
+      Object.values(conditionalSelections) as Conditions[keyof Conditions][]
+    ).map(toSchemaInput);
+
+    return z.union([unionEls[0], unionEls[1], ...unionEls.slice(2)]);
+  })();
+
+  return new BaseQuery({
+    query,
+    schema: newSchema,
+  });
+};
+
+/**
+ * Misc util
+ */
+
+type Field<T extends z.ZodType> = T;
+type FromField<T> = T extends Field<infer R>
+  ? R
+  : T extends [string, infer R]
+  ? R
+  : never;
+export type FromSelection<Sel extends Selection> = z.ZodObject<{
+  [K in keyof Sel]: Sel[K] extends BaseQuery<any>
+    ? Sel[K]["schema"]
+    : FromField<Sel[K]>;
+}>;
+
+export type Selection = Record<
+  string,
+  BaseQuery<any> | z.ZodType | [string, z.ZodType]
+>;
+
+type ConditionSchema<
+  Condition extends Selection | BaseQuery<any> | [string, z.ZodType]
+> = Condition extends Selection
+  ? FromSelection<Condition>
+  : Condition extends BaseQuery<any>
+  ? Condition["schema"]
+  : Condition extends [string, z.ZodType]
+  ? Condition[1]
+  : never;
+
+function extendsBaseQuery<T>(v: T): v is T extends BaseQuery<any> ? T : never {
+  return v instanceof BaseQuery;
+}
+
+function isQuerySchemaTuple<
+  T extends Selection | BaseQuery<any> | [string, z.ZodType]
+>(v: T): v is T extends [string, z.ZodType] ? T : never {
+  return Array.isArray(v);
+}

--- a/src/selectionUtils.ts
+++ b/src/selectionUtils.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+import type { Selection } from "./types";
+import { extendsBaseQuery, isQuerySchemaTuple } from "./typeGuards";
+
+// Recursively define projections to pick up nested conditionals
+export function getProjectionEntriesFromSelection(selection: Selection) {
+  return Object.entries(selection).reduce<string[]>((acc, [key, val]) => {
+    let toPush = "";
+    if (extendsBaseQuery(val)) {
+      toPush = `"${key}": ${val.query}`;
+    } else if (isQuerySchemaTuple(val)) {
+      toPush = `"${key}": ${val[0]}`;
+    } else {
+      toPush = key;
+    }
+
+    if (toPush) acc.push(toPush);
+
+    return acc;
+  }, []);
+}
+
+export function getSchemaFromSelection(selection: Selection): z.ZodObject<any> {
+  return z.object(
+    Object.entries(selection).reduce<z.ZodRawShape>((acc, [key, value]) => {
+      if (extendsBaseQuery(value)) {
+        acc[key] = value.schema;
+      } else if (isQuerySchemaTuple(value)) {
+        acc[key] = value[1];
+      } else if (value instanceof z.ZodType) {
+        acc[key] = value;
+      }
+      return acc;
+    }, {})
+  );
+}

--- a/src/typeGuards.ts
+++ b/src/typeGuards.ts
@@ -12,3 +12,9 @@ export function isQuerySchemaTuple<T>(
 ): v is T extends [string, z.ZodType] ? T : never {
   return Array.isArray(v);
 }
+
+export function isReturnType<T extends (arg: any) => BaseQuery<any>>(
+  v: Parameters<T>[0] | ReturnType<T>
+): v is ReturnType<T> {
+  return v instanceof BaseQuery;
+}

--- a/src/typeGuards.ts
+++ b/src/typeGuards.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+import { BaseQuery } from "./builder";
+
+export function extendsBaseQuery<T>(
+  v: T
+): v is T extends BaseQuery<any> ? T : never {
+  return v instanceof BaseQuery;
+}
+
+export function isQuerySchemaTuple<T>(
+  v: T
+): v is T extends [string, z.ZodType] ? T : never {
+  return Array.isArray(v);
+}

--- a/src/typeGuards.ts
+++ b/src/typeGuards.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { BaseQuery } from "./builder";
+import { BaseQuery } from "./baseQuery";
 
 export function extendsBaseQuery<T>(
   v: T

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 import { BaseQuery } from "./builder";
-import { FromSelection, Selection } from "./grab";
 
 export type ValueOf<T> = T[keyof T];
 
@@ -36,3 +35,24 @@ type ArrayToObj<T extends any[]> = {
 type FieldToObj<T> = {
   [K in T & string]: { [Key in K]: true };
 }[T & string];
+
+/**
+ * Misc internal utils
+ */
+
+type Field<T extends z.ZodType> = T;
+type FromField<T> = T extends Field<infer R>
+  ? R
+  : T extends [string, infer R]
+  ? R
+  : never;
+export type FromSelection<Sel extends Selection> = z.ZodObject<{
+  [K in keyof Sel]: Sel[K] extends BaseQuery<any>
+    ? Sel[K]["schema"]
+    : FromField<Sel[K]>;
+}>;
+
+export type Selection = Record<
+  string,
+  BaseQuery<any> | z.ZodType | [string, z.ZodType]
+>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { BaseQuery } from "./builder";
+import { BaseQuery } from "./baseQuery";
 
 export type ValueOf<T> = T[keyof T];
 

--- a/test-utils/runQuery.ts
+++ b/test-utils/runQuery.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { evaluate, parse } from "groq-js";
 import { pokemonDataset } from "./pokemon";
-import { BaseQuery } from "../src/builder";
+import { BaseQuery } from "../src/baseQuery";
 import { userDataset } from "./users";
 
 const makeQueryRunner =


### PR DESCRIPTION
# Summary
Adds `select()` method to several entities:
- `q.select(conditions: { [condition]: Select | Query | [string, ZodType] }): BaseQuery`
- `EntityQuery.select(conditions | select): EntityQuery`
- `ArrayQuery.select(conditions | select): ArrayQuery`

Pulls out some shared utils between `select` & `grab`

I think this establishes some long desired union type handling around empty objects and/or null being in unions returned from a select. **These changes are only implemented in `select()` & do not effect the current select & union types within `grab()`**

## GROQ Scenarios to Consider
```ts
// #1
*[]{
  ...select({ baseProperty })
}

// #2
*[]{
  "nested": nested{
     ...select({ nestedProperty })
   }
}

// #3
*[]{
  "nested": select({ baseProperty })
}
```

This PR accomplishes the following by:
```ts
// #1
const query1 = q("*").filter().select({
  default: {
    baseProperty: q.string()
  }
})

// #2
const query2 = q("*").filter().grab({
  nested: q('nested').select({
    default: {
      nestedProperty: q.string()
    }
  })
})

// #3
const query3 = q("*").filter().grab({
  nested: q.select({
    default: {
      baseProperty: q.string()
    }
  })
})
```

## API considerations
**Standalone Entities**
A big concept I wanted to tackle here was standalone entities to allow breaking up large queries. Currently this is implemented for projections by following this pattern:
```ts
Import { TypeFromSelection, Selection } from 'groqd'

export const pokemon = {
  id: q.string() 
} satisfies Selection

export type Pokemon = TypeFromSelection<typeof pokemon>

// used in another file in a query
const query = q('*')
  .filter('[ _type == "pokemon" ]')
  .grab(pokemon)
```



**Consolidating Type Inference API**
Since `q.__experimental_select()` returns a `BaseQuery`, the `InferType` util will work on it. ie:
```ts
const select = q.select({
  "foo > 5": {
     bar: q.string()
   }
})

type SelectType = InferType<typeof select>
// ^? { bar: string } | null
// null is added here because there is no default condition
```
I figure a nice step forward is allowing all types to be inferred by `InferType<T>` vs having differing generics to derive the types of different things

**Naming**
I tried to keep parity with `groq` as much as possible, so that's why I called it `.select()` which maps to groqs `select()` function. I think this is a little confusing with the existing `Selection` type which is used to represent the type of the argument we pass into the `.grab()` method to create a projection, however, I think it could be nice to keep our terms as close to `groq` long term as possible

## Next Steps
- update `grab(selection, conditions)` to use `select` under the hood for it's conditions
- Add documentation for `select()`
- ~move from `__experimental_select()` -> `select()`~
- Add standalone `grab` support to compose queries replacing `Selection` usage ie:
```ts
const fooProjection = q.grab({
  foo: q.string()
})

type Foo = InferType<typeof fooProjection>

const query = q('*').filter().grab(fooProjection)
```