### PR TITLE
Additional image metadata fields.

### DIFF
--- a/.changeset/tender-doors-flash.md
+++ b/.changeset/tender-doors-flash.md
@@ -1,0 +1,5 @@
+---
+"groqd": patch
+---
+
+Add hasAlpha, isOpaque, and blurHash options to q.sanityImage's withAsset options.

--- a/README.md
+++ b/README.md
@@ -452,6 +452,9 @@ You can pass an array to the `withAsset` option to specify which fields you want
 - pass `"dimensions"` to query the asset document's `metadata.dimensions` field, useful if you need the image's original dimensions or aspect ratio.
 - pass `"location"` to query the asset document's `metadata.location` field.
 - pass `"lqip"` to query the asset's `metadata.lqip` (Low Quality Image Placeholder) field, useful if you need to display LQIPs.
+- pass `"hasAlpha"` to query the asset's `metadata.hasAlpha` field, useful if you need to know if the image has an alpha channel.
+- pass `"isOpaque"` to query the asset's `metadata.isOpaque` field, useful if you need to know if the image is opaque.
+- pass `"blurHash"` to query the asset's `metadata.blurHash` field, useful if you need to display blurhashes.
 - pass `"palette"` to query the asset document's `metadata.palette` field, useful if you want to use the image's color palette in your UI.
 
 An example:

--- a/src/sanityImage.test.ts
+++ b/src/sanityImage.test.ts
@@ -332,4 +332,32 @@ describe("sanityImage", () => {
     expectTypeOf(palette.vibrant).exclude(null).toEqualTypeOf<Variant>();
     expect(palette.vibrant).toBeTruthy();
   });
+
+  it("can fetch image data with isOpaque, hasAlpha, and blurHash metadata", async () => {
+    const { query, data } = await runPokemonQuery(
+      q("*")
+        .filter("_type == 'pokemon'")
+        .slice(0, 1)
+        .grab({
+          name: q.string(),
+          cover: q.sanityImage("cover", {
+            withAsset: ["hasAlpha", "isOpaque", "blurHash"],
+          }),
+        })
+    );
+
+    expect(query).toBe(
+      `*[_type == 'pokemon'][0..1]{name, "cover": cover{_key, _type, "asset": asset->{"metadata": metadata{isOpaque, hasAlpha, blurHash}}}}`
+    );
+    invariant(data);
+    const metadata = data[0].cover.asset.metadata;
+    expectTypeOf(metadata).toEqualTypeOf<{
+      isOpaque: boolean | null;
+      hasAlpha: boolean | null;
+      blurHash: string | null;
+    }>();
+    expect(metadata.isOpaque).toBe(true);
+    expect(metadata.hasAlpha).toBe(false);
+    expect(metadata.blurHash).toBe("MLCi~.M|00Dj?v~VtR4.IV%Mo~t6M{aeSO");
+  });
 });

--- a/src/sanityImage.ts
+++ b/src/sanityImage.ts
@@ -78,6 +78,16 @@ const locationFields = {
 const lqipFields = {
   lqip: schemas.string(),
 };
+const isOpaqueFields = {
+  isOpaque: schemas.boolean().nullable(),
+};
+const hasAlphaFields = {
+  hasAlpha: schemas.boolean().nullable(),
+};
+const blurHashFields = {
+  blurHash: schemas.string().nullable(),
+};
+
 const getPaletteField = () => schemas.object(paletteFieldSchema).nullable();
 const paletteFields = {
   palette: schemas.object({
@@ -140,7 +150,10 @@ export function sanityImage(fieldName: string, options?: any) {
     assetIncludes("dimensions") && dimensionFields,
     assetIncludes("location") && locationFields,
     assetIncludes("lqip") && lqipFields,
-    assetIncludes("palette") && paletteFields
+    assetIncludes("palette") && paletteFields,
+    assetIncludes("isOpaque") && isOpaqueFields,
+    assetIncludes("hasAlpha") && hasAlphaFields,
+    assetIncludes("blurHash") && blurHashFields
   );
   const assetFields = Object.assign(
     {},
@@ -181,7 +194,15 @@ type ImageRefSchemaType<
     }
 >;
 
-type WithAssetOption = "base" | "dimensions" | "location" | "lqip" | "palette";
+type WithAssetOption =
+  | "base"
+  | "dimensions"
+  | "location"
+  | "lqip"
+  | "palette"
+  | "isOpaque"
+  | "hasAlpha"
+  | "blurHash";
 
 type Asset<
   WithAsset extends readonly WithAssetOption[] | undefined = undefined
@@ -214,6 +235,15 @@ type AssetMetadata<
         : Empty) &
       (ListIncludes<WithAsset, "palette"> extends true
         ? typeof paletteFields
+        : Empty) &
+      (ListIncludes<WithAsset, "hasAlpha"> extends true
+        ? typeof hasAlphaFields
+        : Empty) &
+      (ListIncludes<WithAsset, "isOpaque"> extends true
+        ? typeof isOpaqueFields
+        : Empty) &
+      (ListIncludes<WithAsset, "blurHash"> extends true
+        ? typeof blurHashFields
         : Empty)
   >
 >;


### PR DESCRIPTION
This PR adds `hasAlpha`, `isOpaque`, and `blurHash` options to `sanityImage` 's `withAsset` field. Addresses #81 .