### PR TITLE
feat(sanityImage): make `_type` optional

### DIFF
--- a/.changeset/good-fishes-provide.md
+++ b/.changeset/good-fishes-provide.md
@@ -1,0 +1,5 @@
+---
+"groqd": patch
+---
+
+Make `sanityImage` `imageDimensions._type` an optional field

--- a/src/sanityImage.ts
+++ b/src/sanityImage.ts
@@ -59,7 +59,7 @@ const paletteFieldSchema = {
 const dimensionFields = {
   dimensions: schemas
     .object({
-      _type: schemas.literal("sanity.imageDimensions"),
+      _type: schemas.literal("sanity.imageDimensions").optional(),
       aspectRatio: schemas.number(),
       height: schemas.number(),
       width: schemas.number(),

--- a/test-utils/pokemon.ts
+++ b/test-utils/pokemon.ts
@@ -2057,7 +2057,8 @@ const gen1ImageAssets = gen1.map((mon) => ({
     _type: "sanity.imageMetadata",
     blurHash: "MLCi~.M|00Dj?v~VtR4.IV%Mo~t6M{aeSO",
     dimensions: {
-      _type: "sanity.imageDimensions",
+      // alternate undefined and literal for testing
+      ...(mon.id % 2 === 0 ? { _type: "sanity.imageDimensions" } : ""),
       aspectRatio: 2,
       height: 500,
       width: 1000,


### PR DESCRIPTION
Hello 🏄‍♂️!

I made this change on the back of a discussion on  #83.

Basically when working with a dataset from Sanity, I ran into issues with a missing `_type` field on the Image>Dimension property.

This made me think that others might run into it and that this field is not essential, so could be considered optional.