### PR TITLE
Content block custom markdefs

### DIFF
--- a/.changeset/twelve-ants-thank.md
+++ b/.changeset/twelve-ants-thank.md
@@ -1,0 +1,5 @@
+---
+"groqd": patch
+---
+
+Specify custom markdef types in q.contentBlock[s], addresses #61.

--- a/README.md
+++ b/README.md
@@ -328,7 +328,17 @@ The available schema types are shown below.
     .filter("_type == 'user'")
     .grab({ body: q.array(q.contentBlock()) });
   ```
-- `q.contentBlocks`, a custom Zod schema, to match a list of `q.contentBlock`'s. 
+  Pass an object of the shape `{ markDefs: z.ZodType }` to `q.contentBlock` to specify custom markdef types, useful if you have custom markdefs, e.g.:
+   ```ts
+  q("*")
+    .filter("_type == 'user'")
+    .grab({
+      body: q.array(q.contentBlock({
+        markDefs: q.object({ _type: q.literal("link"), href: q.string() })
+      }))
+    });
+  ```
+- `q.contentBlocks`, a custom Zod schema, to match a list of `q.contentBlock`'s. Pass an argument of the shape `{ markDefs: z.ZodType }` to specify custom markdef types.
   ```ts
   q("*")
     .filter("_type == 'user'")

--- a/src/contentBlock.test.ts
+++ b/src/contentBlock.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, expectTypeOf, it } from "vitest";
+import { runUserQuery } from "../test-utils/runQuery";
+import { q } from "./index";
+import invariant from "tiny-invariant";
+
+describe("contentBlock", () => {
+  it("can handle content blocks", async () => {
+    const { data, query } = await runUserQuery(
+      q("*")
+        .filter("_type == 'user'")
+        .slice(0)
+        .grab({
+          name: q.string(),
+          bio: q.array(q.contentBlock()),
+        })
+    );
+
+    expect(query).toBe(`*[_type == 'user'][0]{name, bio}`);
+    invariant(data);
+    expect(Array.isArray(data.bio)).toBeTruthy();
+    expect(data.bio[0]._type === "block").toBeTruthy();
+  });
+
+  it("allows for custom markDefs", async () => {
+    const { data, query } = await runUserQuery(
+      q("*")
+        .filter("_type == 'user'")
+        .slice(0)
+        .grab({
+          name: q.string(),
+          bio: q.array(
+            q.contentBlock({
+              markDefs: q.union([
+                q.object({ _type: q.literal("link"), href: q.string() }),
+                q.object({ _type: q.literal("note"), note: q.string() }),
+              ]),
+            })
+          ),
+        })
+    );
+
+    expect(query).toBe(`*[_type == 'user'][0]{name, bio}`);
+    invariant(data);
+    expectTypeOf(data.bio[0].markDefs)
+      .exclude(undefined)
+      .toEqualTypeOf<
+        ({ _type: "link"; href: string } | { _type: "note"; note: string })[]
+      >();
+    expect(Array.isArray(data.bio)).toBeTruthy();
+    expect(data.bio[0]._type === "block").toBeTruthy();
+    expect(data.bio[0].markDefs).toEqual([
+      { _type: "link", href: "https://google.com" },
+    ]);
+  });
+});
+
+describe("contentBlocks", () => {
+  it("can handle content blocks", async () => {
+    const { data, query } = await runUserQuery(
+      q("*").filter("_type == 'user'").slice(0).grab({
+        name: q.string(),
+        bio: q.contentBlocks(),
+      })
+    );
+
+    expect(query).toBe(`*[_type == 'user'][0]{name, bio}`);
+    invariant(data);
+    expect(Array.isArray(data.bio)).toBeTruthy();
+    expect(data.bio[0]._type === "block").toBeTruthy();
+  });
+
+  it("allows for custom markDefs", async () => {
+    const { data, query } = await runUserQuery(
+      q("*")
+        .filter("_type == 'user'")
+        .slice(0)
+        .grab({
+          name: q.string(),
+          bio: q.contentBlocks({
+            markDefs: q.union([
+              q.object({ _type: q.literal("link"), href: q.string() }),
+              q.object({ _type: q.literal("note"), note: q.string() }),
+            ]),
+          }),
+        })
+    );
+
+    expect(query).toBe(`*[_type == 'user'][0]{name, bio}`);
+    invariant(data);
+    expectTypeOf(data.bio[0].markDefs)
+      .exclude(undefined)
+      .toEqualTypeOf<
+        ({ _type: "link"; href: string } | { _type: "note"; note: string })[]
+      >();
+    expect(Array.isArray(data.bio)).toBeTruthy();
+    expect(data.bio[0]._type === "block").toBeTruthy();
+    expect(data.bio[0].markDefs).toEqual([
+      { _type: "link", href: "https://google.com" },
+    ]);
+  });
+});

--- a/src/contentBlock.ts
+++ b/src/contentBlock.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+
+/**
+ * Content block schema for standard content blocks.
+ */
+export function contentBlock(): ReturnType<
+  typeof makeContentBlockQuery<typeof baseMarkdefsType>
+>;
+export function contentBlock<T extends z.ZodType>(args: {
+  markDefs: T;
+}): ReturnType<typeof makeContentBlockQuery<T>>;
+export function contentBlock({ markDefs }: { markDefs?: z.ZodType } = {}) {
+  return makeContentBlockQuery(markDefs || baseMarkdefsType);
+}
+
+export function contentBlocks(): z.ZodArray<
+  ReturnType<typeof makeContentBlockQuery<typeof baseMarkdefsType>>
+>;
+export function contentBlocks<T extends z.ZodType>(args: {
+  markDefs: T;
+}): z.ZodArray<ReturnType<typeof makeContentBlockQuery<T>>>;
+export function contentBlocks({ markDefs }: { markDefs?: z.ZodType } = {}) {
+  return z.array(makeContentBlockQuery(markDefs || baseMarkdefsType));
+}
+
+function makeContentBlockQuery<T extends z.ZodType>(markDefs: T) {
+  return z.object({
+    _type: z.literal("block"),
+    _key: z.string().optional(),
+    children: z.array(
+      z.object({
+        _key: z.string(),
+        _type: z.string(),
+        text: z.string(),
+        marks: z.array(z.string()),
+      })
+    ),
+    markDefs: z.array(markDefs).optional(),
+    style: z.string().optional(),
+    listItem: z.string().optional(),
+    level: z.number().optional(),
+  });
+}
+
+const baseMarkdefsType = z
+  .object({
+    _type: z.string(),
+    _key: z.string(),
+  })
+  .catchall(z.unknown());

--- a/src/schemas.test.ts
+++ b/src/schemas.test.ts
@@ -195,41 +195,6 @@ describe("object", () => {
   });
 });
 
-describe("contentBlock", () => {
-  it("can handle content blocks", async () => {
-    const { data, query } = await runUserQuery(
-      q("*")
-        .filter("_type == 'user'")
-        .slice(0)
-        .grab({
-          name: q.string(),
-          bio: q.array(q.contentBlock()),
-        })
-    );
-
-    expect(query).toBe(`*[_type == 'user'][0]{name, bio}`);
-    invariant(data);
-    expect(Array.isArray(data.bio)).toBeTruthy();
-    expect(data.bio[0]._type === "block").toBeTruthy();
-  });
-});
-
-describe("contentBlock", () => {
-  it("can handle content blocks", async () => {
-    const { data, query } = await runUserQuery(
-      q("*").filter("_type == 'user'").slice(0).grab({
-        name: q.string(),
-        bio: q.contentBlocks(),
-      })
-    );
-
-    expect(query).toBe(`*[_type == 'user'][0]{name, bio}`);
-    invariant(data);
-    expect(Array.isArray(data.bio)).toBeTruthy();
-    expect(data.bio[0]._type === "block").toBeTruthy();
-  });
-});
-
 describe("slug", () => {
   it("can handle slugs", async () => {
     const { data, query } = await runUserQuery(

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { contentBlock, contentBlocks } from "./contentBlock";
 
 /**
  * Custom date schema that will parse date strings to Date objects
@@ -7,38 +8,6 @@ const dateSchema = () =>
   z.preprocess((arg) => {
     if (typeof arg == "string" || arg instanceof Date) return new Date(arg);
   }, z.date());
-
-/**
- * Content block schema for standard content blocks.
- */
-const contentBlock = () =>
-  z.object({
-    _type: z.literal("block"),
-    _key: z.string().optional(),
-    children: z.array(
-      z.object({
-        _key: z.string(),
-        _type: z.string(),
-        text: z.string(),
-        marks: z.array(z.string()),
-      })
-    ),
-    markDefs: z
-      .array(
-        z
-          .object({
-            _type: z.string(),
-            _key: z.string(),
-          })
-          .catchall(z.unknown())
-      )
-      .optional(),
-    style: z.string().optional(),
-    listItem: z.string().optional(),
-    level: z.number().optional(),
-  });
-
-const contentBlocks = () => z.array(contentBlock());
 
 const slug = (fieldName: string) =>
   [`${fieldName}.current`, z.string()] as [string, z.ZodString];


### PR DESCRIPTION
Addresses #61, extends `q.contentBlock` a bit to allow specifying a custom markdef schema.