### PR TITLE
feat: accept "image" type in  contentBlock

### DIFF
--- a/src/contentBlock.ts
+++ b/src/contentBlock.ts
@@ -24,22 +24,32 @@ export function contentBlocks({ markDefs }: { markDefs?: z.ZodType } = {}) {
 }
 
 function makeContentBlockQuery<T extends z.ZodType>(markDefs: T) {
-  return z.object({
-    _type: z.literal("block"),
-    _key: z.string().optional(),
-    children: z.array(
+  return z
+    .object({
+      _type: z.literal("block"),
+      _key: z.string().optional(),
+      children: z.array(
+        z.object({
+          _key: z.string(),
+          _type: z.string(),
+          text: z.string(),
+          marks: z.array(z.string()),
+        })
+      ),
+      markDefs: z.array(markDefs).optional(),
+      style: z.string().optional(),
+      listItem: z.string().optional(),
+      level: z.number().optional(),
+    })
+    .or(
       z.object({
-        _key: z.string(),
-        _type: z.string(),
-        text: z.string(),
-        marks: z.array(z.string()),
+        _type: z.literal("image"),
+        asset: z.object({
+          _ref: z.string(),
+          _type: z.literal("reference"),
+        }),
       })
-    ),
-    markDefs: z.array(markDefs).optional(),
-    style: z.string().optional(),
-    listItem: z.string().optional(),
-    level: z.number().optional(),
-  });
+    );
 }
 
 const baseMarkdefsType = z

--- a/test-utils/sampleContentBlocks.ts
+++ b/test-utils/sampleContentBlocks.ts
@@ -71,4 +71,12 @@ export const sampleContentBlocks = [
     markDefs: [],
     style: "normal",
   },
+  {
+    _key: "d0ad5f54dce1",
+    _type: "image",
+    asset: {
+      _ref: "image-9423cb7859d34db14222b9e19c37-2560x1707-jpg",
+      _type: "reference",
+    },
+  },
 ];


### PR DESCRIPTION
Hey there 🌊

This PR extends the `makeContentBlockQuery` to allow the use of `image` as a block as per Sanity [Docs](https://www.sanity.io/docs/portable-text-editor-configuration#ec55d49cfe6c)

Resolves #91.