### PR TITLE
Long time coming: more legible error messages.

### DIFF
--- a/.changeset/hot-taxis-explode.md
+++ b/.changeset/hot-taxis-explode.md
@@ -1,0 +1,5 @@
+---
+"groqd": minor
+---
+
+Update `makeSafeQueryRunner` to provide more legible error message when parsing fails

--- a/docs/utility-methods.md
+++ b/docs/utility-methods.md
@@ -26,7 +26,7 @@ const data = await runQuery(
 );
 ```
 
-In Sanity workflows, you might also want to pass e.g. params to your `client.fetch` call. To support this, add additional arguments to your `makeSafeQueryRunner` argument's arguments as below.
+In Sanity workflows, you might also want to pass e.g. params to your `client.fetch` call. To support this add additional arguments to your `makeSafeQueryRunner` query executor's arguments as below.
 
 ```ts
 // ...

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { schemas } from "./schemas";
 import { select } from "./select";
 
 export type { InferType, TypeFromSelection, Selection } from "./types";
-export { makeSafeQueryRunner } from "./makeSafeQueryRunner";
+export { makeSafeQueryRunner, GroqdParseError } from "./makeSafeQueryRunner";
 export { nullToUndefined } from "./nullToUndefined";
 
 export const pipe = (filter: string): UnknownQuery => {

--- a/src/makeSafeQueryRunner.test.ts
+++ b/src/makeSafeQueryRunner.test.ts
@@ -1,8 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { GroqdParseError, q } from ".";
 import { makeSafeQueryRunner } from "./makeSafeQueryRunner";
-import { runPokemonQuery } from "../test-utils/runQuery";
-import { z } from "zod";
 
 describe("makeSafeQueryRunner", () => {
   it("should create a query runner with single argument", async () => {
@@ -39,11 +37,26 @@ describe("makeSafeQueryRunner", () => {
   });
 
   it("should have better error message", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const fn = vi.fn((_query: string) => Promise.resolve({ foo: "bar" }));
+    const runQuery = makeSafeQueryRunner((query) => fn(query));
+
+    try {
+      await runQuery(q("*").grab({ foo: q.literal("baz") }));
+    } catch (e) {
+      expect(e).toBeInstanceOf(GroqdParseError);
+      expect(e instanceof Error && e.message).toBe(
+        'Error parsing `result.foo`: Invalid literal value, expected "baz".'
+      );
+    }
+  });
+
+  it("should have better error message (for nested arrays/objects)", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const fn = vi.fn((_query: string) =>
       Promise.resolve([{ things: [{ name: 123 }] }])
     );
     const runQuery = makeSafeQueryRunner((query) => fn(query));
-    console.log("Running...");
 
     try {
       await runQuery(

--- a/src/makeSafeQueryRunner.ts
+++ b/src/makeSafeQueryRunner.ts
@@ -10,7 +10,35 @@ export const makeSafeQueryRunner =
     { query, schema }: BaseQuery<T>,
     ...rest: ButFirst<Parameters<Fn>>
   ): Promise<z.infer<T>> =>
-    fn(query, ...rest).then((res) => schema.parse(res));
+    fn(query, ...rest).then((res) => {
+      try {
+        return schema.parse(res);
+      } catch (e) {
+        if (e instanceof z.ZodError) {
+          const errorPath = `result${e.errors[0].path.reduce((acc, el) => {
+            if (typeof el === "string") {
+              return `${acc}.${el}`;
+            }
+            return `${acc}[${el}]`;
+          }, "")}`;
+
+          throw new GroqdParseError(
+            `Error parsing \`${errorPath}\`: ${e.errors[0].message}.`,
+            e
+          );
+        }
+
+        throw e;
+      }
+    });
+
+export class GroqdParseError extends Error {
+  zodError: z.ZodError;
+  constructor(public readonly message: string, zodError: z.ZodError) {
+    super(message);
+    this.zodError = zodError;
+  }
+}
 
 type BaseType<T = any> = z.ZodType<T>;
 type ButFirst<T extends unknown[]> = T extends [unknown, ...infer U]

--- a/src/makeSafeQueryRunner.ts
+++ b/src/makeSafeQueryRunner.ts
@@ -14,29 +14,24 @@ export const makeSafeQueryRunner =
       try {
         return schema.parse(res);
       } catch (e) {
-        if (e instanceof z.ZodError) {
-          const errorPath = `result${e.errors[0].path.reduce((acc, el) => {
-            if (typeof el === "string") {
-              return `${acc}.${el}`;
-            }
-            return `${acc}[${el}]`;
-          }, "")}`;
-
-          throw new GroqdParseError(
-            `Error parsing \`${errorPath}\`: ${e.errors[0].message}.`,
-            e
-          );
-        }
-
+        if (e instanceof z.ZodError) throw new GroqdParseError(e);
         throw e;
       }
     });
 
 export class GroqdParseError extends Error {
-  zodError: z.ZodError;
-  constructor(public readonly message: string, zodError: z.ZodError) {
-    super(message);
-    this.zodError = zodError;
+  readonly zodError: z.ZodError;
+  // zodError: z.ZodError;
+  constructor(public readonly err: z.ZodError) {
+    const errorPath = `result${err.errors[0].path.reduce((acc, el) => {
+      if (typeof el === "string") {
+        return `${acc}.${el}`;
+      }
+      return `${acc}[${el}]`;
+    }, "")}`;
+
+    super(`Error parsing \`${errorPath}\`: ${err.errors[0].message}.`);
+    this.zodError = err;
   }
 }
 


### PR DESCRIPTION
Right now, when `makeSafeQueryRunner` fails to parse a response (because of schema validation), it just throws a straight-up Zod error. Zod errors contain a lot of info, but can be really hard to read/grok in the terminal. This PR just adds a bit of sugar on top of `z.ZodError` to give a concise indication of the (first) thing that breaks validation. E.g., can get an error message like this:

```txt
Error parsing `result[12].things[5].name`: Expected string, received number.
```

which should be useful, especially with larger lists of content.