### PR TITLE
`isArray` option for `q()`

### DIFF
--- a/.changeset/rude-chicken-divide.md
+++ b/.changeset/rude-chicken-divide.md
@@ -1,0 +1,5 @@
+---
+"groqd": minor
+---
+
+Optional isArray option for q()/pipe() method

--- a/README.md
+++ b/README.md
@@ -102,6 +102,15 @@ export const runQuery = makeSafeQueryRunner((query) => client.fetch(query));
 const data = await runQuery(q("*").filter("_type == 'pokemon'"));
 ```
 
+### Starting with an array
+
+Sometimes your base query returns an array. `groqd` has no way of knowing when this occurs, so you'll need to give it a hint by passing `isArray: true` to the second arg of `q`.
+
+```ts
+q("*[_type == 'pokemon']", { isArray: true })
+  .grab$({ name: q.string() })
+```
+
 ### `.grab`
 
 Available on `UnknownQuery`, `ArrayQuery`, and `EntityQuery`, handles [projections](https://www.sanity.io/docs/how-queries-work#727ecb6f5e15), or selecting fields from an existing set of documents. This is the primary mechanism for providing a schema for the data you expect to get.

--- a/docs/query-building.md
+++ b/docs/query-building.md
@@ -30,6 +30,15 @@ export const runQuery = makeSafeQueryRunner((query) => client.fetch(query));
 const data = await runQuery(q("*").filter("_type == 'pokemon'"));
 ```
 
+### Starting with an array
+
+Sometimes your base query returns an array. `groqd` has no way of knowing when this occurs, so you'll need to give it a hint by passing `isArray: true` to the second arg of `q`.
+
+```ts
+q("*[_type == 'pokemon']", { isArray: true })
+  .grab$({ name: q.string() })
+```
+
 ## `.filter`
 
 Receives a single string argument for the GROQ filter to be applied (without the surrounding `[` and `]`). Applies the GROQ filter to the query and adjusts schema accordingly.

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,9 +21,6 @@ export function pipe(
     ? new UnknownArrayQuery({ query: filter })
     : new UnknownQuery({ query: filter });
 }
-// export const pipe = (filter: string): UnknownQuery => {
-//   return new UnknownQuery({ query: filter });
-// };
 
 pipe.sanityImage = sanityImage;
 pipe.select = select;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { UnknownQuery } from "./builder";
+import { UnknownArrayQuery, UnknownQuery } from "./builder";
 import { sanityImage } from "./sanityImage";
 import { schemas } from "./schemas";
 import { select } from "./select";
@@ -8,9 +8,22 @@ export type { InferType, TypeFromSelection, Selection } from "./types";
 export { makeSafeQueryRunner, GroqdParseError } from "./makeSafeQueryRunner";
 export { nullToUndefined } from "./nullToUndefined";
 
-export const pipe = (filter: string): UnknownQuery => {
-  return new UnknownQuery({ query: filter });
-};
+export function pipe(filter: string): UnknownQuery;
+export function pipe<IsArray extends boolean>(
+  filter: string,
+  opts: { isArray: IsArray }
+): IsArray extends true ? UnknownArrayQuery : UnknownQuery;
+export function pipe(
+  filter: string,
+  { isArray = false }: { isArray?: boolean } = {}
+) {
+  return isArray
+    ? new UnknownArrayQuery({ query: filter })
+    : new UnknownQuery({ query: filter });
+}
+// export const pipe = (filter: string): UnknownQuery => {
+//   return new UnknownQuery({ query: filter });
+// };
 
 pipe.sanityImage = sanityImage;
 pipe.select = select;

--- a/src/pipe.test.ts
+++ b/src/pipe.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, expectTypeOf, it } from "vitest";
+import { UnknownArrayQuery, UnknownQuery } from "./builder";
+import { q } from "./index";
+import { runPokemonQuery } from "../test-utils/runQuery";
+import invariant from "tiny-invariant";
+
+describe("pipe", () => {
+  it("returns instance of UnknownQuery with query set to first arg", () => {
+    const result = q("foo");
+    expect(result).toBeInstanceOf(UnknownQuery);
+    expect(result.query).toBe("foo");
+  });
+
+  it("can return instance of UnknownArrayQuery when isArray is true", () => {
+    const result = q("foo", { isArray: true });
+    expect(result).toBeInstanceOf(UnknownArrayQuery);
+    expect(result.query).toBe("foo");
+  });
+
+  it("can chain .grab$ after q() if isArray = true", async () => {
+    const { data, query } = await runPokemonQuery(
+      q("*[_type == 'pokemon'][0..2]", { isArray: true }).grab$({
+        name: q.string(),
+      })
+    );
+
+    expect(query).toBe("*[_type == 'pokemon'][0..2]{name}");
+    invariant(data);
+    expectTypeOf(data).toEqualTypeOf<{ name: string }[]>();
+    expect(data[0].name).toBe("Bulbasaur");
+  });
+});


### PR DESCRIPTION
Addresses #97 by adding an `isArray` option to `q()` so you can pass a more sophisticated base query that returns an array, without having to do a ton of additional method chaining. Can be useful if you want to "mostly just use groq" and then use `.grab$` with schemas to add in types.