### PR TITLE
formideploy setup

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,54 @@
+name: Deploy Docs Site
+
+on:
+  push:
+    paths:
+      - 'docs/**'
+      - 'website/**'
+  pull_request:
+    branches:
+      - 'main'
+    paths:
+      - 'docs/**'
+      - 'website/**'
+
+jobs:
+  deploy-website:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: 'yarn'
+
+      - name: AWS CLI version
+        run: "aws --version"
+
+      - name: Install Dependencies
+        run: yarn install --frozen-lockfile
+        working-directory: ./website
+
+      - name: Build the website
+        run: yarn build
+        working-directory: ./website
+
+      # Use `gh` tool to infer more information about the pull request.
+      # The underlying issue here is pushes to a non-mergeable/main target branch
+      # don't have the PR number easily available.
+      # https://stackoverflow.com/a/70102700
+      - name: Get pull request info
+        id: pr_info
+        run: echo "::set-output name=pull_request_number::$(gh pr view --json number -q .number || echo "")"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Deploy docs (production)
+        if: github.ref == 'refs/heads/main'
+        run: yarn deploy:prod
+        working-directory: ./website
+        env:
+          GITHUB_DEPLOYMENT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/website/formideploy.config.js
+++ b/website/formideploy.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  lander: {
+    name: "groqd",
+  },
+  build: {
+    // Build output directory.
+    // Docusaurus defaults to `build`.
+    // We use `docusaurus build --out-dir build/open-source/docusaurus` to build intermediate real dirs.
+    dir: "build",
+  },
+};

--- a/website/package.json
+++ b/website/package.json
@@ -13,7 +13,6 @@
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
     "typecheck": "tsc",
-    "deploy:stage": "formideploy deploy --staging",
     "deploy:prod": "formideploy deploy --production"
   },
   "dependencies": {

--- a/website/package.json
+++ b/website/package.json
@@ -5,14 +5,16 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
-    "build": "docusaurus build",
+    "build": "docusaurus build --out-dir build/open-source/groqd",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
-    "typecheck": "tsc"
+    "typecheck": "tsc",
+    "deploy:stage": "formideploy deploy --staging",
+    "deploy:prod": "formideploy deploy --production"
   },
   "dependencies": {
     "@docusaurus/core": "2.3.1",


### PR DESCRIPTION
Setting up formideploy to deploy docs to `formidable.com/open-source/groqd`. Still need to get TF/AWS access keys setup.