### PR TITLE
Add `filterByType` convenience method

### DIFF
--- a/.changeset/metal-carrots-invent.md
+++ b/.changeset/metal-carrots-invent.md
@@ -1,0 +1,5 @@
+---
+"groqd": minor
+---
+
+Add filterByType convenience method

--- a/docs/query-building.md
+++ b/docs/query-building.md
@@ -48,6 +48,15 @@ q("*").filter("_type == 'pokemon'");
 // translates to: *[_type == 'pokemon']
 ```
 
+## `.filterByType`
+
+Receives a single string argument as a convenience method to apply a GROQ filter by type. Applies a GROQ filter by type to the query and adjusts schema accordingly.
+
+```ts
+q("*").filterByType("pokemon");
+// translates to: *[_type == 'pokemon']
+```
+
 ## `.grab`
 
 

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -97,10 +97,7 @@ export class UnknownQuery extends EntityQuery<z.ZodUnknown> {
   }
 
   filterByType(filterTypeValue: string) {
-    this.query += `[_type == '${filterTypeValue}']`;
-    return new UnknownArrayQuery({
-      ...this.value(),
-    });
+    return this.filter(`_type == '${filterTypeValue}'`);
   }
 
   deref() {

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -96,6 +96,13 @@ export class UnknownQuery extends EntityQuery<z.ZodUnknown> {
     });
   }
 
+  filterByType(filterTypeValue: string) {
+    this.query += `[_type == '${filterTypeValue}']`;
+    return new UnknownArrayQuery({
+      ...this.value(),
+    });
+  }
+
   deref() {
     this.query += "->";
     return this;
@@ -129,6 +136,11 @@ export class ArrayQuery<T extends z.ZodTypeAny> extends BaseQuery<
 
   filter(filterValue = "") {
     this.query += `[${filterValue}]`;
+    return this;
+  }
+
+  filterByType(filterTypeValue: string) {
+    this.query += `[_type == '${filterTypeValue}']`;
     return this;
   }
 

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -137,8 +137,7 @@ export class ArrayQuery<T extends z.ZodTypeAny> extends BaseQuery<
   }
 
   filterByType(filterTypeValue: string) {
-    this.query += `[_type == '${filterTypeValue}']`;
-    return this;
+    return this.filter(`_type == '${filterTypeValue}'`);
   }
 
   grab<


### PR DESCRIPTION
Add `filterByType` convenience method to receive a single string argument and apply a GROQ filter by type.