### PR TITLE
Fix `q.sanityImage` types

### DIFF
--- a/.changeset/giant-flowers-exist.md
+++ b/.changeset/giant-flowers-exist.md
@@ -1,0 +1,5 @@
+---
+"groqd": minor
+---
+
+Deprecate q.sanityImage in favor of standalone sanityImage method, address #109

--- a/docs/utility-methods.md
+++ b/docs/utility-methods.md
@@ -80,17 +80,19 @@ q("*")
 The [`.grab$`](/query-building#grab-1) and [`.grabOne$`](/query-building#grabone-1) methods use this under the hood – in most instances, we recommend you just use `.grab$` and `.grabOne$` instead of this utility.
 :::
 
-## `q.sanityImage`
+## `sanityImage`
 
 A convenience method to make it easier to generate image queries for Sanity's image type. Supports fetching various info from both `image` documents and `asset` documents.
 
 In its simplest form, it looks something like this:
 
 ```ts
+import { q, sanityImage } from "groqd";
+
 q("*")
   .filter("_type == 'pokemon'")
   .grab({
-    cover: q.sanityImage("cover"), // 👈 just pass the field name
+    cover: sanityImage("cover"), // 👈 just pass the field name
   });
 
 // -> { cover: { _key: string; _type: string; asset: { _type: "reference"; _ref: string; } } }[]
@@ -98,21 +100,25 @@ q("*")
 
 which will allow you to fetch the minimal/basic image document information.
 
-### `q.sanityImage`'s `isList` option
+:::info
+`sanityImage` used to be attached to `q` as `q.sanityImage`. Due to its complexity, it has since been moved out into its own standalone utility method.  
+:::
 
-If you have an array of image documents, you can pass `isList: true` to an options object as the second argument to `q.sanityImage` method.
+### `sanityImage`'s `isList` option
+
+If you have an array of image documents, you can pass `isList: true` to an options object as the second argument to `sanityImage` method.
 
 ```ts
 q("*")
   .filter("_type == 'pokemon'")
   .grab({
-    images: q.sanityImage("images", { isList: true }), // 👈 fetch as a list
+    images: sanityImage("images", { isList: true }), // 👈 fetch as a list
   });
 
 // -> { images: { ... }[] }[]
 ```
 
-### `q.sanityImage`'s `withCrop` option
+### `sanityImage`'s `withCrop` option
 
 Sanity's image document has fields for crop information, which you can query for with the `withCrop` option.
 
@@ -120,13 +126,13 @@ Sanity's image document has fields for crop information, which you can query for
 q("*")
   .filter("_type == 'pokemon'")
   .grab({
-    cover: q.sanityImage("cover", { withCrop: true }), // 👈 fetch crop info
+    cover: sanityImage("cover", { withCrop: true }), // 👈 fetch crop info
   });
 
 // -> { cover: { ..., crop: { top: number; bottom: number; left: number; right: number; } | null } }[]
 ```
 
-### `q.sanityImage`'s `withHotspot` option
+### `sanityImage`'s `withHotspot` option
 
 Sanity's image document has fields for hotspot information, which you can query for with the `withHotspot` option.
 
@@ -134,13 +140,13 @@ Sanity's image document has fields for hotspot information, which you can query 
 q("*")
   .filter("_type == 'pokemon'")
   .grab({
-    cover: q.sanityImage("cover", { withHotpot: true }), // 👈 fetch hotspot info
+    cover: sanityImage("cover", { withHotpot: true }), // 👈 fetch hotspot info
   });
 
 // -> { cover: { ..., hotspot: { x: number; y: number; height: number; width: number; } | null } }[]
 ```
 
-### `q.sanityImage`'s `additionalFields` option
+### `sanityImage`'s `additionalFields` option
 
 Sanity allows you to add additional fields to their image documents, such as alt text or descriptions. The `additionalFields` option allows you to specify such fields to query with your image query.
 
@@ -148,7 +154,7 @@ Sanity allows you to add additional fields to their image documents, such as alt
 q("*")
   .filter("_type == 'pokemon'")
   .grab({
-    cover: q.sanityImage("cover", {
+    cover: sanityImage("cover", {
       // 👇 fetch additional fields
       additionalFields: {
         alt: q.string(),
@@ -160,9 +166,9 @@ q("*")
 // -> { cover: { ..., alt: string, description: string } }[]
 ```
 
-### `q.sanityImage`'s `withAsset` option
+### `sanityImage`'s `withAsset` option
 
-Sanity's image documents have a reference to an asset document that contains a whole host of information relative to the uploaded image asset itself. The `q.sanityImage` will allow you to dereference this asset document and query various fields from it.
+Sanity's image documents have a reference to an asset document that contains a whole host of information relative to the uploaded image asset itself. The `sanityImage` will allow you to dereference this asset document and query various fields from it.
 
 You can pass an array to the `withAsset` option to specify which fields you want to query from the asset document:
 
@@ -181,7 +187,7 @@ An example:
 q("*")
   .filter("_type == 'pokemon'")
   .grab({
-    cover: q.sanityImage("cover", {
+    cover: sanityImage("cover", {
       withAsset: ["base", "dimensions"],
     }),
   });

--- a/packages/groqd/package.json
+++ b/packages/groqd/package.json
@@ -39,6 +39,7 @@
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
     "build": "tsup",
+    "build:watch": "tsup --watch",
     "preversion": "yarn check:ci"
   },
   "devDependencies": {

--- a/packages/groqd/src/addDeprecationMessage.ts
+++ b/packages/groqd/src/addDeprecationMessage.ts
@@ -1,0 +1,9 @@
+export function addDeprecationMessage<Fn extends (...args: any[]) => any>(
+  fn: Fn,
+  message: string
+): Fn {
+  return <Fn>function (...args: any[]) {
+    console.warn(message);
+    return fn(...args);
+  };
+}

--- a/packages/groqd/src/index.ts
+++ b/packages/groqd/src/index.ts
@@ -3,6 +3,7 @@ import { UnknownArrayQuery, UnknownQuery } from "./builder";
 import { sanityImage } from "./sanityImage";
 import { schemas } from "./schemas";
 import { select } from "./select";
+import { addDeprecationMessage } from "./addDeprecationMessage";
 
 export type { InferType, TypeFromSelection, Selection } from "./types";
 export { makeSafeQueryRunner, GroqdParseError } from "./makeSafeQueryRunner";
@@ -22,7 +23,10 @@ export function pipe(
     : new UnknownQuery({ query: filter });
 }
 
-pipe.sanityImage = sanityImage;
+pipe.sanityImage = addDeprecationMessage(
+  sanityImage,
+  "`q.sanityImage` is being deprecated in favor of importing `sanityImage` directly from `groqd`. `q.sanityImage` will be removed in future versions."
+);
 pipe.select = select;
 
 // Add schemas
@@ -35,4 +39,4 @@ export const q = pipe as Pipe;
 /**
  * Export zod for convenience
  */
-export { z };
+export { z, sanityImage };

--- a/packages/groqd/src/index.ts
+++ b/packages/groqd/src/index.ts
@@ -25,7 +25,7 @@ export function pipe(
 
 pipe.sanityImage = addDeprecationMessage(
   sanityImage,
-  "`q.sanityImage` is being deprecated in favor of importing `sanityImage` directly from `groqd`. `q.sanityImage` will be removed in future versions."
+  "`q.sanityImage` has been deprecated in favor of importing `sanityImage` directly from `groqd`. `q.sanityImage` will be removed in future versions."
 );
 pipe.select = select;
 

--- a/packages/groqd/src/sanityImage.test.ts
+++ b/packages/groqd/src/sanityImage.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, expectTypeOf, it } from "vitest";
 import { runPokemonQuery } from "../test-utils/runQuery";
-import { q } from "./index";
+import { q, sanityImage } from "./index";
 import invariant from "tiny-invariant";
 
 describe("sanityImage", () => {
@@ -11,7 +11,7 @@ describe("sanityImage", () => {
         .slice(0, 1)
         .grab({
           name: q.string(),
-          cover: q.sanityImage("cover"),
+          cover: sanityImage("cover"),
         })
     );
 
@@ -43,7 +43,7 @@ describe("sanityImage", () => {
         .slice(0, 1)
         .grab({
           name: q.string(),
-          cover: q.sanityImage("cover", { withCrop: true }),
+          cover: sanityImage("cover", { withCrop: true }),
         })
     );
 
@@ -75,7 +75,7 @@ describe("sanityImage", () => {
         .slice(0, 1)
         .grab({
           name: q.string(),
-          cover: q.sanityImage("cover", { withHotspot: true }),
+          cover: sanityImage("cover", { withHotspot: true }),
         })
     );
 
@@ -107,7 +107,7 @@ describe("sanityImage", () => {
         .slice(0, 1)
         .grab({
           name: q.string(),
-          cover: q.sanityImage("cover", {
+          cover: sanityImage("cover", {
             additionalFields: {
               description: q.string(),
             },
@@ -137,7 +137,7 @@ describe("sanityImage", () => {
         .slice(0, 1)
         .grab({
           name: q.string(),
-          images: q.sanityImage("images", {
+          images: sanityImage("images", {
             withCrop: true,
             isList: true,
             additionalFields: {
@@ -170,7 +170,7 @@ describe("sanityImage", () => {
         .slice(0, 1)
         .grab({
           name: q.string(),
-          cover: q.sanityImage("cover", {
+          cover: sanityImage("cover", {
             withAsset: ["base"],
           }),
         })
@@ -209,7 +209,7 @@ describe("sanityImage", () => {
         .slice(1, 1)
         .grab({
           name: q.string(),
-          cover: q.sanityImage("cover", {
+          cover: sanityImage("cover", {
             withAsset: ["dimensions"],
           }),
         })
@@ -241,7 +241,7 @@ describe("sanityImage", () => {
         .slice(0, 1)
         .grab({
           name: q.string(),
-          cover: q.sanityImage("cover", {
+          cover: sanityImage("cover", {
             withAsset: ["dimensions"],
           }),
         })
@@ -273,7 +273,7 @@ describe("sanityImage", () => {
         .slice(0, 1)
         .grab({
           name: q.string(),
-          cover: q.sanityImage("cover", {
+          cover: sanityImage("cover", {
             withAsset: ["location"],
           }),
         })
@@ -301,7 +301,7 @@ describe("sanityImage", () => {
         .slice(0, 1)
         .grab({
           name: q.string(),
-          cover: q.sanityImage("cover", {
+          cover: sanityImage("cover", {
             withAsset: ["lqip"],
           }),
         })
@@ -325,7 +325,7 @@ describe("sanityImage", () => {
         .slice(0, 1)
         .grab({
           name: q.string(),
-          cover: q.sanityImage("cover", {
+          cover: sanityImage("cover", {
             withAsset: ["palette"],
           }),
         })
@@ -374,7 +374,7 @@ describe("sanityImage", () => {
         .slice(0, 1)
         .grab({
           name: q.string(),
-          cover: q.sanityImage("cover", {
+          cover: sanityImage("cover", {
             withAsset: ["hasAlpha", "isOpaque", "blurHash"],
           }),
         })


### PR DESCRIPTION
#98 introduced a TS overload for the main `pipe` fn, which makes types more complicated. The `sanityImage` also has pretty messy types, and when combined together – the image types just flop to `any`. This PR extracts that `sanityImage` out into its own standalone import, and puts a deprecation notice on the `q.sanityImage` for the time being. This resolves the type issue, and is probably a better approach long term as we continue to do type acrobatics.

Addresses #109 