### PR TITLE
Expose `makeContentBlockQuery` helper

### DIFF
--- a/.changeset/soft-beans-visit.md
+++ b/.changeset/soft-beans-visit.md
@@ -1,0 +1,5 @@
+---
+"groqd": patch
+---
+
+Expose makeContentBlockQuery function for more flexibility around block content querying.

--- a/docs/utility-methods.md
+++ b/docs/utility-methods.md
@@ -194,3 +194,30 @@ q("*")
 
 // -> { cover: { ..., asset: { extension: string; mimeType: string; ...; metadata: { dimensions: { aspectRatio: number; height: number; width: number; }; }; }; } }[]
 ```
+
+## `makeContentBlockQuery`
+
+`groqd` offers a [`q.contentBlock`](./schema-types.md#qcontentblock) utility method. Under the hood, it uses `makeContentBlockQuery` which generates a content block query that is passed into `z.object` under the hood. This utility method is exposed publicly for cases where you need a little bit of additional flexibility around block content queries.
+
+The raw source code for this function is shown below if you need a reference to the specific fields it returns.
+
+```ts
+export function makeContentBlockQuery<T extends z.ZodType>(markDefs: T) {
+  return {
+    _type: z.string(),
+    _key: z.string().optional(),
+    children: z.array(
+      z.object({
+        _key: z.string(),
+        _type: z.string(),
+        text: z.string(),
+        marks: z.array(z.string()),
+      })
+    ),
+    markDefs: z.array(markDefs).optional(),
+    style: z.string().optional(),
+    listItem: z.string().optional(),
+    level: z.number().optional(),
+  };
+}
+```

--- a/packages/groqd/src/contentBlock.ts
+++ b/packages/groqd/src/contentBlock.ts
@@ -3,28 +3,28 @@ import { z } from "zod";
 /**
  * Content block schema for standard content blocks.
  */
-export function contentBlock(): ReturnType<
-  typeof makeContentBlockQuery<typeof baseMarkdefsType>
+export function contentBlock(): z.ZodObject<
+  ReturnType<typeof makeContentBlockQuery<typeof baseMarkdefsType>>
 >;
 export function contentBlock<T extends z.ZodType>(args: {
   markDefs: T;
-}): ReturnType<typeof makeContentBlockQuery<T>>;
+}): z.ZodObject<ReturnType<typeof makeContentBlockQuery<T>>>;
 export function contentBlock({ markDefs }: { markDefs?: z.ZodType } = {}) {
-  return makeContentBlockQuery(markDefs || baseMarkdefsType);
+  return z.object(makeContentBlockQuery(markDefs || baseMarkdefsType));
 }
 
 export function contentBlocks(): z.ZodArray<
-  ReturnType<typeof makeContentBlockQuery<typeof baseMarkdefsType>>
+  z.ZodObject<ReturnType<typeof makeContentBlockQuery<typeof baseMarkdefsType>>>
 >;
 export function contentBlocks<T extends z.ZodType>(args: {
   markDefs: T;
-}): z.ZodArray<ReturnType<typeof makeContentBlockQuery<T>>>;
+}): z.ZodArray<z.ZodObject<ReturnType<typeof makeContentBlockQuery<T>>>>;
 export function contentBlocks({ markDefs }: { markDefs?: z.ZodType } = {}) {
-  return z.array(makeContentBlockQuery(markDefs || baseMarkdefsType));
+  return z.array(z.object(makeContentBlockQuery(markDefs || baseMarkdefsType)));
 }
 
-function makeContentBlockQuery<T extends z.ZodType>(markDefs: T) {
-  return z.object({
+export function makeContentBlockQuery<T extends z.ZodType>(markDefs: T) {
+  return {
     _type: z.string(),
     _key: z.string().optional(),
     children: z.array(
@@ -39,7 +39,7 @@ function makeContentBlockQuery<T extends z.ZodType>(markDefs: T) {
     style: z.string().optional(),
     listItem: z.string().optional(),
     level: z.number().optional(),
-  });
+  };
 }
 
 const baseMarkdefsType = z

--- a/packages/groqd/src/index.ts
+++ b/packages/groqd/src/index.ts
@@ -8,6 +8,7 @@ import { addDeprecationMessage } from "./addDeprecationMessage";
 export type { InferType, TypeFromSelection, Selection } from "./types";
 export { makeSafeQueryRunner, GroqdParseError } from "./makeSafeQueryRunner";
 export { nullToUndefined } from "./nullToUndefined";
+export { makeContentBlockQuery } from "./contentBlock";
 
 export function pipe(filter: string): UnknownQuery;
 export function pipe<IsArray extends boolean>(


### PR DESCRIPTION
This PR exposes a `makeContentBlockQuery` function to give users access to the underlying utility used for `q.contentBlock` in case they need to construct their own block content logic.