### PR TITLE
Publish playground editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
     "build:packages": "pnpm run --filter groqd --filter groqd-playground build",
     "build": "pnpm run -r build",
     "changeset": "changeset",
-    "version": "pnpm changeset version && pnpm install --no-frozen-lockfile && git add .",
+    "version": "pnpm changeset version && pnpm install --no-frozen-lockfile",
     "start:docs": "pnpm run --filter website start",
     "build:docs": "pnpm run --filter website build",
-    "dev:playground": "concurrently \"pnpm run --filter groqd dev\" \"pnpm run --filter playground-editor dev\" \"pnpm run --filter groqd-playground dev\" \"pnpm run --filter playground-example dev\"",
+    "dev:playground": "concurrently \"pnpm run --filter groqd dev\" \"pnpm run --filter groqd-playground-editor dev\" \"pnpm run --filter groqd-playground dev\" \"pnpm run --filter playground-example dev\"",
     "dev:editor": "pnpm run --filter playground-editor dev"
   },
   "devDependencies": {

--- a/packages/groqd-playground/src/Playground.tsx
+++ b/packages/groqd-playground/src/Playground.tsx
@@ -410,7 +410,7 @@ export default function GroqdPlayground({ tool }: GroqdPlaygroundProps) {
 const IS_DEV = process.env.MODE === "development";
 const EDITOR_ORIGIN = IS_DEV
   ? "http://localhost:3069"
-  : "https://groqd-playground-editor.formidable.dev";
+  : "https://unpkg.com/groqd-playground-editor@0.0.2/build/index.html";
 
 type Params = Record<string, string | number>;
 type State = {

--- a/packages/playground-editor/README.md
+++ b/packages/playground-editor/README.md
@@ -1,0 +1,3 @@
+# Groqd Playground Editor
+
+You probably shouldn't `npm install` this. This package is used as part of [Groqd Playground](https://github.com/FormidableLabs/groqd/tree/main/packages/groqd-playground) and consumed via unpkg.

--- a/packages/playground-editor/package.json
+++ b/packages/playground-editor/package.json
@@ -1,15 +1,26 @@
 {
-  "name": "playground-editor",
+  "name": "groqd-playground-editor",
   "description": "Code editor for GROQD playground. GROQD Playground will consume this via iframe.",
-  "version": "1.0.1",
+  "version": "0.0.1",
   "main": "index.js",
   "license": "MIT",
-  "private": true,
+  "private": false,
+  "author": {
+    "name": "Formidable",
+    "url": "https://formidable.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/formidablelabs/groqd.git"
+  },
+  "homepage": "https://github.com/formidablelabs/groqd",
+  "files": ["build"],
   "scripts": {
     "dev": "pnpm run gather-types && webpack serve --mode development",
     "build": "pnpm run gather-types && webpack --mode production",
     "gather-types": "node ./scripts/gather-types.js",
-    "typecheck": "pnpm run gather-types && tsc --noEmit"
+    "typecheck": "pnpm run gather-types && tsc --noEmit",
+    "prepublishOnly": "pnpm run build"
   },
   "devDependencies": {
     "@babel/core": "^7.21.4",

--- a/packages/playground-editor/package.json
+++ b/packages/playground-editor/package.json
@@ -1,8 +1,8 @@
 {
   "name": "groqd-playground-editor",
   "description": "Code editor for GROQD playground. GROQD Playground will consume this via iframe.",
-  "version": "0.0.1",
-  "main": "index.js",
+  "version": "0.0.2",
+  "main": "build/index.html",
   "license": "MIT",
   "private": false,
   "author": {


### PR DESCRIPTION
Instead of hosting playground editor on our own Vercel instance, just publish static build files to npm and consume via `unpkg`. This has many benefits, including:

- we don't maintain infra/cost
- we can easily do semver with the iframe url, since unpkg handles that out of the box.

**NOTE:** I've already published this package and updated permissions/tokens, so no changeset file needed here.