### PR TITLE
What's that? More playground features?

### DIFF
--- a/.changeset/shiny-rabbits-appear.md
+++ b/.changeset/shiny-rabbits-appear.md
@@ -1,0 +1,6 @@
+---
+"groqd-playground-editor": patch
+"groqd-playground": patch
+---
+
+More playground features!

--- a/packages/groqd-playground/src/Playground.tsx
+++ b/packages/groqd-playground/src/Playground.tsx
@@ -57,6 +57,13 @@ export default function GroqdPlayground({ tool }: GroqdPlaygroundProps) {
     };
   });
   const iframeRef = React.useRef<HTMLIFrameElement>(null);
+  const editorContainer = React.useRef<HTMLDivElement>(null);
+  const editorInitialWidth = React.useMemo(
+    () =>
+      +(localStorage.getItem(STORAGE_KEYS.EDITOR_WIDTH) || 0) ||
+      EDITOR_INITIAL_WIDTH,
+    []
+  );
   const copyShareUrl = useCopyUrlAndNotify("Copied share URL to clipboard!");
   const windowHref = window.location.href;
 
@@ -210,6 +217,16 @@ export default function GroqdPlayground({ tool }: GroqdPlaygroundProps) {
     iframeRef.current && emitReset(iframeRef.current, EDITOR_ORIGIN);
   };
 
+  const handleEditorResize = () => {
+    const container = editorContainer.current;
+    if (!container) return;
+
+    localStorage.setItem(
+      STORAGE_KEYS.EDITOR_WIDTH,
+      String(container.clientWidth)
+    );
+  };
+
   const responseView = (() => {
     if (isFetching) {
       return (
@@ -323,15 +340,19 @@ export default function GroqdPlayground({ tool }: GroqdPlaygroundProps) {
       </Card>
 
       <Box flex={1}>
-        <Split style={{ width: "100%", height: "100%", overflow: "hidden" }}>
+        <Split
+          style={{ width: "100%", height: "100%", overflow: "hidden" }}
+          onDragEnd={handleEditorResize}
+        >
           <div
             style={{
-              width: EDITOR_INITIAL_WIDTH,
+              width: editorInitialWidth,
               minWidth: 200,
               height: "100%",
               display: "flex",
               flexDirection: "column",
             }}
+            ref={editorContainer}
           >
             <div style={{ flex: 1, position: "relative" }}>
               <iframe
@@ -493,7 +514,7 @@ const reducer = (state: State, action: Action): State => {
   }
 };
 
-const EDITOR_INITIAL_WIDTH = 400;
+const EDITOR_INITIAL_WIDTH = 500;
 
 const inputSchema = z.object({
   event: z.literal("INPUT"),

--- a/packages/groqd-playground/src/Playground.tsx
+++ b/packages/groqd-playground/src/Playground.tsx
@@ -139,6 +139,7 @@ export default function GroqdPlayground({ tool }: GroqdPlaygroundProps) {
             copyShareUrl(window.location.href);
           }
 
+          let playgroundRunQueryCount = 0;
           const libs = {
             groqd: q,
             playground: {
@@ -146,6 +147,11 @@ export default function GroqdPlayground({ tool }: GroqdPlaygroundProps) {
                 query: BaseQuery<any>,
                 params?: Record<string, string | number>
               ) => {
+                playgroundRunQueryCount++;
+                if (playgroundRunQueryCount > 1) return;
+
+                console.log(playgroundRunQueryCount);
+
                 try {
                   if (query instanceof q.BaseQuery) {
                     dispatch({

--- a/packages/groqd-playground/src/Playground.tsx
+++ b/packages/groqd-playground/src/Playground.tsx
@@ -23,6 +23,7 @@ import { useDatasets } from "./useDatasets";
 import { API_VERSIONS, DEFAULT_API_VERSION, STORAGE_KEYS } from "./consts";
 import { ShareUrlField } from "./components/ShareUrlField";
 import { useCopyUrlAndNotify } from "./hooks/copyUrl";
+import { emitReset } from "./messaging";
 
 export default function GroqdPlayground({ tool }: GroqdPlaygroundProps) {
   const [
@@ -55,6 +56,7 @@ export default function GroqdPlayground({ tool }: GroqdPlaygroundProps) {
       isFetching: false,
     };
   });
+  const iframeRef = React.useRef<HTMLIFrameElement>(null);
   const copyShareUrl = useCopyUrlAndNotify("Copied share URL to clipboard!");
   const windowHref = window.location.href;
 
@@ -150,8 +152,6 @@ export default function GroqdPlayground({ tool }: GroqdPlaygroundProps) {
                 playgroundRunQueryCount++;
                 if (playgroundRunQueryCount > 1) return;
 
-                console.log(playgroundRunQueryCount);
-
                 try {
                   if (query instanceof q.BaseQuery) {
                     dispatch({
@@ -204,6 +204,10 @@ export default function GroqdPlayground({ tool }: GroqdPlaygroundProps) {
   };
   const handleAPIVersionChange = (apiVersion: string) => {
     dispatch({ type: "SET_ACTIVE_API_VERSION", payload: { apiVersion } });
+  };
+
+  const handleReset = () => {
+    iframeRef.current && emitReset(iframeRef.current, EDITOR_ORIGIN);
   };
 
   const responseView = (() => {
@@ -335,9 +339,15 @@ export default function GroqdPlayground({ tool }: GroqdPlaygroundProps) {
                 width="100%"
                 height="100%"
                 style={{ border: "none" }}
+                ref={iframeRef}
               />
               <div style={{ position: "absolute", bottom: 12, left: 12 }}>
-                <Button icon={ResetIcon} text="Reset" mode="ghost" />
+                <Button
+                  icon={ResetIcon}
+                  text="Reset"
+                  mode="ghost"
+                  onClick={handleReset}
+                />
               </div>
             </div>
             <Card paddingTop={3} paddingBottom={3} borderTop>

--- a/packages/groqd-playground/src/Playground.tsx
+++ b/packages/groqd-playground/src/Playground.tsx
@@ -458,7 +458,7 @@ export default function GroqdPlayground({ tool }: GroqdPlaygroundProps) {
 const EDITOR_ORIGIN =
   process.env.SANITY_STUDIO_GROQD_PLAYGROUND_ENV === "development"
     ? "http://localhost:3069"
-    : "https://unpkg.com/groqd-playground-editor@0.0.2/build/index.html";
+    : "https://unpkg.com/groqd-playground-editor@0.0.3/build/index.html";
 
 type Params = Record<string, string | number>;
 type State = {

--- a/packages/groqd-playground/src/consts.ts
+++ b/packages/groqd-playground/src/consts.ts
@@ -2,6 +2,7 @@ export const STORAGE_KEYS = {
   DATASET: "__groqd_playground_dataset",
   API_VERSION: "__groqd_playground_api_version",
   CODE: "__groqd_playground_code",
+  EDITOR_WIDTH: "__groqd_playground_editor_width",
 };
 
 export const API_VERSIONS = ["v1", "vX", "v2021-03-25", "v2021-10-21"];

--- a/packages/groqd-playground/src/messaging.ts
+++ b/packages/groqd-playground/src/messaging.ts
@@ -1,0 +1,6 @@
+export const emitReset = (iframe: HTMLIFrameElement, target: string) => {
+  iframe.contentWindow?.postMessage(
+    JSON.stringify({ event: "RESET_CODE" }),
+    target
+  );
+};

--- a/packages/playground-editor/src/twoslashInlays.ts
+++ b/packages/playground-editor/src/twoslashInlays.ts
@@ -4,8 +4,8 @@ import * as monaco from "monaco-editor";
 export const createTwoslashInlayProvider = () => {
   const provider: monaco.languages.InlayHintsProvider = {
     provideInlayHints: async (model, _, cancel) => {
-      const text = model.getValue();
-      const queryRegex = /runQuery\(/gm;
+      const editorText = model.getValue();
+      const queryRegex = /(\n\s*\n)^(.*)runQuery\(/gm;
       let match;
       const results: monaco.languages.InlayHint[] = [];
       const worker = await (
@@ -19,8 +19,8 @@ export const createTwoslashInlayProvider = () => {
         };
       }
 
-      while ((match = queryRegex.exec(text)) !== null) {
-        const end = match.index;
+      while ((match = queryRegex.exec(editorText)) !== null) {
+        const end = match.index + match[1].length + match[2].length;
         const endPos = model.getPositionAt(end);
         const inspectionPos = new monaco.Position(
           endPos.lineNumber,


### PR DESCRIPTION
A little hard to keep track of everything as I hammer out features, but this one includes:

- Display of query execution time.
- Persisting editor pane width between reloads.
- Reset functionality, where pressing `Reset` button actually resets the code in the editor.
- Minor tweak to type inlay hints in the editor, so that type hint only shows if there's an empty line above a `runQuery` call. (Without this, the type hint can just jump right into the line above it and muddy that line up.)