### PR TITLE
Playground: Init with messages

### DIFF
--- a/.changeset/cold-stingrays-sleep.md
+++ b/.changeset/cold-stingrays-sleep.md
@@ -1,0 +1,6 @@
+---
+"groqd-playground-editor": patch
+"groqd-playground": patch
+---
+
+Init editor iframe with postMessage instead of query params

--- a/packages/groqd-playground/src/Playground.tsx
+++ b/packages/groqd-playground/src/Playground.tsx
@@ -153,7 +153,6 @@ export default function GroqdPlayground({ tool }: GroqdPlaygroundProps) {
         const payload = messageSchema.parse(JSON.parse(message.data));
 
         if (payload.event === "READY") {
-          message.source;
           const storedCode =
             new URL(window.location.href).searchParams.get("code") ||
             localStorage.getItem(STORAGE_KEYS.CODE);

--- a/packages/groqd-playground/src/Playground.tsx
+++ b/packages/groqd-playground/src/Playground.tsx
@@ -153,13 +153,15 @@ export default function GroqdPlayground({ tool }: GroqdPlaygroundProps) {
         const payload = messageSchema.parse(JSON.parse(message.data));
 
         if (payload.event === "READY") {
+          message.source;
           const storedCode =
             new URL(window.location.href).searchParams.get("code") ||
             localStorage.getItem(STORAGE_KEYS.CODE);
 
-          iframeRef.current &&
-            emitInit(iframeRef.current, EDITOR_ORIGIN, {
+          message.source &&
+            emitInit(message.source, EDITOR_ORIGIN, {
               code: storedCode || undefined,
+              origin: window.location.origin,
             });
         } else if (payload.event === "INPUT") {
           localStorage.setItem(STORAGE_KEYS.CODE, payload.compressedRawCode);

--- a/packages/groqd-playground/src/Playground.tsx
+++ b/packages/groqd-playground/src/Playground.tsx
@@ -24,7 +24,7 @@ import { useDatasets } from "./useDatasets";
 import { API_VERSIONS, DEFAULT_API_VERSION, STORAGE_KEYS } from "./consts";
 import { ShareUrlField } from "./components/ShareUrlField";
 import { useCopyUrlAndNotify } from "./hooks/copyUrl";
-import { emitReset } from "./messaging";
+import { emitReset, emitInit } from "./messaging";
 
 export default function GroqdPlayground({ tool }: GroqdPlaygroundProps) {
   const [
@@ -152,7 +152,16 @@ export default function GroqdPlayground({ tool }: GroqdPlaygroundProps) {
       try {
         const payload = messageSchema.parse(JSON.parse(message.data));
 
-        if (payload.event === "INPUT") {
+        if (payload.event === "READY") {
+          const storedCode =
+            new URL(window.location.href).searchParams.get("code") ||
+            localStorage.getItem(STORAGE_KEYS.CODE);
+
+          iframeRef.current &&
+            emitInit(iframeRef.current, EDITOR_ORIGIN, {
+              code: storedCode || undefined,
+            });
+        } else if (payload.event === "INPUT") {
           localStorage.setItem(STORAGE_KEYS.CODE, payload.compressedRawCode);
           setQP("code", payload.compressedRawCode);
 
@@ -204,18 +213,6 @@ export default function GroqdPlayground({ tool }: GroqdPlaygroundProps) {
     return () => {
       window.removeEventListener("message", handleMessage);
     };
-  }, []);
-
-  const iframeSrc = React.useMemo(() => {
-    const url = new URL(EDITOR_ORIGIN);
-    url.searchParams.append("host", window.location.href);
-
-    const storedCode =
-      new URL(window.location.href).searchParams.get("code") ||
-      localStorage.getItem(STORAGE_KEYS.CODE);
-    if (storedCode) url.searchParams.append("code", storedCode);
-
-    return url.toString();
   }, []);
 
   const handleDatasetChange = (datasetName: string) => {
@@ -381,7 +378,7 @@ export default function GroqdPlayground({ tool }: GroqdPlaygroundProps) {
           >
             <div style={{ flex: 1, position: "relative" }}>
               <iframe
-                src={iframeSrc}
+                src={EDITOR_ORIGIN}
                 width="100%"
                 height="100%"
                 style={{ border: "none" }}
@@ -546,6 +543,10 @@ const reducer = (state: State, action: Action): State => {
 
 const EDITOR_INITIAL_WIDTH = 500;
 
+const readySchema = z.object({
+  event: z.literal("READY"),
+});
+
 const inputSchema = z.object({
   event: z.literal("INPUT"),
   compressedRawCode: z.string(),
@@ -559,7 +560,7 @@ const errorSchema = z.object({
   message: z.string(),
 });
 
-const messageSchema = z.union([inputSchema, errorSchema]);
+const messageSchema = z.union([inputSchema, errorSchema, readySchema]);
 
 const url = new URL(window.location.href);
 const setQP = (key: string, value: string) => {

--- a/packages/groqd-playground/src/Playground.tsx
+++ b/packages/groqd-playground/src/Playground.tsx
@@ -457,7 +457,7 @@ export default function GroqdPlayground({ tool }: GroqdPlaygroundProps) {
 const EDITOR_ORIGIN =
   process.env.SANITY_STUDIO_GROQD_PLAYGROUND_ENV === "development"
     ? "http://localhost:3069"
-    : "https://unpkg.com/groqd-playground-editor@0.0.3/build/index.html";
+    : "https://unpkg.com/groqd-playground-editor@0.0.4/build/index.html";
 
 type Params = Record<string, string | number>;
 type State = {

--- a/packages/groqd-playground/src/messaging.ts
+++ b/packages/groqd-playground/src/messaging.ts
@@ -4,3 +4,14 @@ export const emitReset = (iframe: HTMLIFrameElement, target: string) => {
     target
   );
 };
+
+export const emitInit = (
+  iframe: HTMLIFrameElement,
+  target: string,
+  payload: { code?: string }
+) => {
+  iframe.contentWindow?.postMessage(
+    JSON.stringify({ event: "INIT", code: payload.code }),
+    target
+  );
+};

--- a/packages/groqd-playground/src/messaging.ts
+++ b/packages/groqd-playground/src/messaging.ts
@@ -6,12 +6,11 @@ export const emitReset = (iframe: HTMLIFrameElement, target: string) => {
 };
 
 export const emitInit = (
-  iframe: HTMLIFrameElement,
+  source: MessageEventSource,
   target: string,
-  payload: { code?: string }
+  payload: { code?: string; origin: string }
 ) => {
-  iframe.contentWindow?.postMessage(
-    JSON.stringify({ event: "INIT", code: payload.code }),
-    target
-  );
+  source.postMessage(JSON.stringify({ event: "INIT", ...payload }), {
+    targetOrigin: target,
+  });
 };

--- a/packages/playground-editor/src/messaging.ts
+++ b/packages/playground-editor/src/messaging.ts
@@ -1,12 +1,8 @@
-let targetUrl = "";
-const getTargetUrl = () => {
-  if (!targetUrl) {
-    const params = new URLSearchParams(window.location.search);
-    targetUrl = params.get("host") || "";
-  }
-
-  return targetUrl;
-};
+/**
+ * NOTE: Using "*" as target for postMessages. Generally, this is a no-no.
+ * In this case, we don't care who embeds the editor – go to town, if you'd like.
+ * The _consumer_ is responsible for validating messages coming from the editor (by checking message.origin)
+ */
 
 const IS_EMBEDDED = window.location !== window.parent.location;
 
@@ -31,15 +27,17 @@ export const emitInput = ({
       requestImmediateFetch,
       requestShareCopy,
     }),
-    getTargetUrl()
+    "*"
   );
 };
 
 export const emitError = (message: string) => {
   if (!IS_EMBEDDED) return;
 
-  window.parent.postMessage(
-    JSON.stringify({ event: "ERROR", message }),
-    getTargetUrl()
-  );
+  window.parent.postMessage(JSON.stringify({ event: "ERROR", message }), "*");
+};
+
+export const emitReady = () => {
+  if (!IS_EMBEDDED) return;
+  window.parent.postMessage(JSON.stringify({ event: "READY" }), "*");
 };

--- a/packages/playground-editor/src/messaging.ts
+++ b/packages/playground-editor/src/messaging.ts
@@ -6,17 +6,20 @@
 
 const IS_EMBEDDED = window.location !== window.parent.location;
 
-export const emitInput = ({
-  compressedRawCode,
-  code,
-  requestImmediateFetch,
-  requestShareCopy,
-}: {
-  compressedRawCode: string;
-  code: string;
-  requestImmediateFetch: boolean;
-  requestShareCopy?: boolean;
-}) => {
+export const emitInput = (
+  {
+    compressedRawCode,
+    code,
+    requestImmediateFetch,
+    requestShareCopy,
+  }: {
+    compressedRawCode: string;
+    code: string;
+    requestImmediateFetch: boolean;
+    requestShareCopy?: boolean;
+  },
+  target: string
+) => {
   if (!IS_EMBEDDED) return;
 
   window.parent.postMessage(
@@ -27,17 +30,20 @@ export const emitInput = ({
       requestImmediateFetch,
       requestShareCopy,
     }),
-    "*"
+    target
   );
 };
 
-export const emitError = (message: string) => {
+export const emitError = (message: string, target: string) => {
   if (!IS_EMBEDDED) return;
 
-  window.parent.postMessage(JSON.stringify({ event: "ERROR", message }), "*");
+  window.parent.postMessage(
+    JSON.stringify({ event: "ERROR", message }),
+    target
+  );
 };
 
-export const emitReady = () => {
+export const emitReady = (target: string) => {
   if (!IS_EMBEDDED) return;
-  window.parent.postMessage(JSON.stringify({ event: "READY" }), "*");
+  window.parent.postMessage(JSON.stringify({ event: "READY" }), target);
 };

--- a/packages/playground-editor/src/messaging.ts
+++ b/packages/playground-editor/src/messaging.ts
@@ -1,9 +1,3 @@
-/**
- * NOTE: Using "*" as target for postMessages. Generally, this is a no-no.
- * In this case, we don't care who embeds the editor – go to town, if you'd like.
- * The _consumer_ is responsible for validating messages coming from the editor (by checking message.origin)
- */
-
 const IS_EMBEDDED = window.location !== window.parent.location;
 
 export const emitInput = (
@@ -43,7 +37,16 @@ export const emitError = (message: string, target: string) => {
   );
 };
 
-export const emitReady = (target: string) => {
+/**
+ * Using "*" as postMessage target is generally a no-no.
+ * For our "READY" event, we can't reliably know the cross-origin parent, so we'll emit to everyone.
+ * On the consuming side, we'll do an origin check – and then respond to the event with the origin to use in follow-up messages.
+ *
+ * This message payload contains no useful information, so no biggy if it's intercepted.
+ * The postMessage listener also checks that responders to this message are the parent window,
+ *   so this message will only be responded to from an embedding window.
+ */
+export const emitReady = () => {
   if (!IS_EMBEDDED) return;
-  window.parent.postMessage(JSON.stringify({ event: "READY" }), target);
+  window.parent.postMessage(JSON.stringify({ event: "READY" }), "*");
 };


### PR DESCRIPTION
Since `unpkg` doesn't preserve query params, we can't initiative with query params. Opting for a postMessage init approach where:

- editor emits a "READY" event to anyone listening.
- playground picks up that "READY" event and responds with an "INIT" payload, including the parent origin.
- editor picks up that "INIT" payload and initiates the editor with it.
- then it's business as usual, editor using parent origin as target for following messages.