### PR TITLE
Playground: JSON Inspector

### DIFF
--- a/packages/groqd-playground/package.json
+++ b/packages/groqd-playground/package.json
@@ -43,6 +43,7 @@
   },
   "devDependencies": {
     "@types/react": "^18.0.35",
+    "@types/styled-components": "^5.1.26",
     "tsup": "^6.7.0",
     "typescript": "^4.9.5"
   },

--- a/packages/groqd-playground/src/Playground.tsx
+++ b/packages/groqd-playground/src/Playground.tsx
@@ -23,7 +23,7 @@ import { GroqdPlaygroundProps } from "./types";
 import { useDatasets } from "./useDatasets";
 import { API_VERSIONS, DEFAULT_API_VERSION, STORAGE_KEYS } from "./consts";
 import { ShareUrlField } from "./components/ShareUrlField";
-import { useCopyUrlAndNotify } from "./hooks/copyUrl";
+import { useCopyDataAndNotify } from "./hooks/copyDataToClipboard";
 import { emitReset, emitInit } from "./messaging";
 import { JSONExplorer } from "./components/JSONExplorer";
 
@@ -68,7 +68,7 @@ export default function GroqdPlayground({ tool }: GroqdPlaygroundProps) {
       EDITOR_INITIAL_WIDTH,
     []
   );
-  const copyShareUrl = useCopyUrlAndNotify("Copied share URL to clipboard!");
+  const copyShareUrl = useCopyDataAndNotify("Copied share URL to clipboard!");
   const windowHref = window.location.href;
 
   // Configure client
@@ -289,27 +289,27 @@ export default function GroqdPlayground({ tool }: GroqdPlaygroundProps) {
           <Box paddingX={3} marginY={3}>
             <Label muted>Raw Response {execTimeDisplay}</Label>
           </Box>
-          <Box
-            flex={1}
-            paddingX={3}
-            paddingBottom={3}
-            paddingTop={1}
-            overflow="auto"
-          >
-            <JSONExplorer data={rawResponse} highlightedPaths={errorPaths} />
-          </Box>
+          {/*<Box*/}
+          {/*  flex={1}*/}
+          {/*  paddingX={3}*/}
+          {/*  paddingBottom={3}*/}
+          {/*  paddingTop={1}*/}
+          {/*  overflow="auto"*/}
+          {/*>*/}
+          <JSONExplorer data={rawResponse} highlightedPaths={errorPaths} />
+          {/*</Box>*/}
         </Flex>
       );
     }
 
     return (
-      <Flex flex={1} direction="column">
+      <Flex flex={1} direction="column" style={{ maxHeight: "100%" }}>
         <Box padding={3}>
           <Label muted>Query Response {execTimeDisplay}</Label>
         </Box>
-        <Box flex={1} overflow="auto" padding={3}>
-          {parsedResponse ? <JSONExplorer data={parsedResponse} /> : null}
-        </Box>
+        {/*<Box flex={1} overflow="auto" padding={3}>*/}
+        {parsedResponse ? <JSONExplorer data={parsedResponse} /> : null}
+        {/*</Box>*/}
       </Flex>
     );
   })();

--- a/packages/groqd-playground/src/Playground.tsx
+++ b/packages/groqd-playground/src/Playground.tsx
@@ -285,15 +285,7 @@ export default function GroqdPlayground({ tool }: GroqdPlaygroundProps) {
           <Box paddingX={3} marginY={3}>
             <Label muted>Raw Response {execTimeDisplay}</Label>
           </Box>
-          {/*<Box*/}
-          {/*  flex={1}*/}
-          {/*  paddingX={3}*/}
-          {/*  paddingBottom={3}*/}
-          {/*  paddingTop={1}*/}
-          {/*  overflow="auto"*/}
-          {/*>*/}
           <JSONExplorer data={rawResponse} highlightedPaths={errorPaths} />
-          {/*</Box>*/}
         </Flex>
       );
     }
@@ -303,9 +295,7 @@ export default function GroqdPlayground({ tool }: GroqdPlaygroundProps) {
         <Box padding={3}>
           <Label muted>Query Response {execTimeDisplay}</Label>
         </Box>
-        {/*<Box flex={1} overflow="auto" padding={3}>*/}
         {parsedResponse ? <JSONExplorer data={parsedResponse} /> : null}
-        {/*</Box>*/}
       </Flex>
     );
   })();

--- a/packages/groqd-playground/src/Playground.tsx
+++ b/packages/groqd-playground/src/Playground.tsx
@@ -140,16 +140,12 @@ export default function GroqdPlayground({ tool }: GroqdPlaygroundProps) {
         payload: { parsedResponse: data },
       });
     } catch (err) {
-      console.log("ERRORED");
       let errorPaths: Map<string, string> | undefined;
       if (err instanceof q.GroqdParseError) {
-        console.log("IS ZOD ERROR");
         errorPaths = new Map();
         for (const e of err.zodError.errors) {
           errorPaths.set(e.path.map((v) => String(v)).join("."), e.message);
         }
-
-        console.log(errorPaths);
       }
 
       dispatch({

--- a/packages/groqd-playground/src/Playground.tsx
+++ b/packages/groqd-playground/src/Playground.tsx
@@ -275,11 +275,11 @@ export default function GroqdPlayground({ tool }: GroqdPlaygroundProps) {
 
     if (fetchParseError) {
       return (
-        <Flex style={{ height: "100%" }} direction="column">
+        <Flex flex={1} direction="column">
           <Box marginY={3} paddingX={3}>
             <Label muted>Error</Label>
           </Box>
-          <Box paddingX={3}>
+          <Box paddingX={3} style={{ maxHeight: 250 }} overflow="auto">
             <pre>
               {fetchParseError instanceof Error
                 ? fetchParseError.message

--- a/packages/groqd-playground/src/components/JSONExplorer.styled.tsx
+++ b/packages/groqd-playground/src/components/JSONExplorer.styled.tsx
@@ -1,0 +1,57 @@
+import styled from "styled-components";
+import { Box } from "@sanity/ui";
+
+export const Root = styled.div`
+  font-family: Menlo, monospace;
+  font-size: 0.9em;
+`;
+
+export const Label = styled.span`
+  color: #9d1fcd;
+  @media (prefers-color-scheme: dark) {
+    color: #d05afc;
+  }
+`;
+
+export const Key = styled.span`
+  color: #1e61cd;
+  @media (prefers-color-scheme: dark) {
+    color: #5998fc;
+  }
+`;
+export const Value = styled.span`
+  color: #967e1c;
+  @media (prefers-color-scheme: dark) {
+    color: #dbb931;
+  }
+`;
+
+export const LineItem = styled(Box)<{
+  depth: number;
+  pointer?: boolean;
+  hasError?: boolean;
+}>`
+  padding-left: ${({ depth }) => depth * DEPTH_SC}px;
+  border-radius: 4px;
+  cursor: ${({ pointer }) => (pointer ? "pointer" : "initial")};
+
+  background-color: ${({ hasError }) => (hasError ? "#ffe5ea" : "initial")};
+
+  &:hover {
+    background-color: ${({ hasError }) => (hasError ? undefined : "#e7e7e7")};
+  }
+
+  @media (prefers-color-scheme: dark) {
+    background-color: ${({ hasError }) => (hasError ? "#470417" : "initial")};
+
+    &:hover {
+      background-color: ${({ hasError }) => (hasError ? undefined : "#505050")};
+    }
+  }
+`;
+
+export const ErrorMessageText = styled.div`
+  font-weight: 400;
+`;
+
+const DEPTH_SC = 15;

--- a/packages/groqd-playground/src/components/JSONExplorer.styled.tsx
+++ b/packages/groqd-playground/src/components/JSONExplorer.styled.tsx
@@ -1,9 +1,10 @@
 import styled from "styled-components";
 import { Box } from "@sanity/ui";
 
-export const Root = styled.div`
+export const Root = styled(Box)`
   font-family: Menlo, monospace;
   font-size: 0.9em;
+  position: relative;
 `;
 
 export const Label = styled.span`

--- a/packages/groqd-playground/src/components/JSONExplorer.tsx
+++ b/packages/groqd-playground/src/components/JSONExplorer.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Box, Stack, usePrefersDark } from "@sanity/ui";
+import { Box, Button, Stack } from "@sanity/ui";
 import {
   Root,
   Label,
@@ -8,6 +8,8 @@ import {
   LineItem,
   ErrorMessageText,
 } from "./JSONExplorer.styled";
+import { CopyIcon } from "@sanity/icons";
+import { useCopyDataAndNotify } from "../hooks/copyDataToClipboard";
 
 type JSONExplorerDisplayProps = {
   data: unknown;
@@ -17,9 +19,32 @@ type JSONExplorerDisplayProps = {
 };
 
 export const JSONExplorer = (props: JSONExplorerDisplayProps) => {
+  const copyUrl = useCopyDataAndNotify("Copied JSON to clipboard!");
+  const handleCopy = () => {
+    try {
+      copyUrl(JSON.stringify(props.data, null, 2));
+    } catch {}
+  };
+
   return (
-    <Root>
-      <JSONExplorerDisplay {...props} />
+    <Root flex={1}>
+      <Box
+        padding={3}
+        style={{ position: "absolute", inset: 0 }}
+        overflow="auto"
+      >
+        <JSONExplorerDisplay {...props} />
+      </Box>
+      <Box style={{ position: "absolute", bottom: 0, right: 0 }} padding={3}>
+        <Button
+          aria-label="Copy to clipboard"
+          type="button"
+          mode="ghost"
+          icon={CopyIcon}
+          text="Copy to clipboard"
+          onClick={handleCopy}
+        />
+      </Box>
     </Root>
   );
 };
@@ -92,7 +117,12 @@ const JSONExplorerDisplay = ({
 
   // Primitive leafs
   return (
-    <LineItem paddingY={1} depth={depth} hasError={!!errorMessage}>
+    <LineItem
+      paddingY={1}
+      depth={depth}
+      hasError={!!errorMessage}
+      id={`item-${currentPath}`}
+    >
       <Stack space={1}>
         {errorMessage && <ErrorMessageText>{errorMessage}</ErrorMessageText>}
         <div>

--- a/packages/groqd-playground/src/components/JSONExplorer.tsx
+++ b/packages/groqd-playground/src/components/JSONExplorer.tsx
@@ -1,0 +1,81 @@
+import * as React from "react";
+
+type JSONExplorerProps = {
+  data: unknown;
+  prefix?: string;
+  highlightedPaths?: Map<string, string>;
+  currentPath?: string;
+};
+
+export const JSONExplorer = ({
+  data,
+  prefix,
+  highlightedPaths,
+  currentPath = "",
+}: JSONExplorerProps) => {
+  const prefixDisplay = prefix !== undefined ? `${prefix}:  ` : "";
+  const errorMessage = highlightedPaths && highlightedPaths.get(currentPath);
+
+  // Arrays
+  if (Array.isArray(data)) {
+    return (
+      <div>
+        <div>
+          {prefixDisplay}[...] {data.length} items
+        </div>
+        <div style={{ marginLeft: 12 }}>
+          {data.map((dat, i) => (
+            <JSONExplorer
+              data={dat}
+              key={i}
+              prefix={String(i)}
+              currentPath={addToPath(currentPath, String(i))}
+              highlightedPaths={highlightedPaths}
+            />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  // Objects
+  if (isObject(data)) {
+    return (
+      <div>
+        <div>
+          {prefixDisplay}
+          {`{...}`}
+          {Object.keys(data).length} properties
+        </div>
+        <div style={{ marginLeft: 12 }}>
+          {Object.entries(data).map(([key, dat]) => (
+            <JSONExplorer
+              data={dat}
+              key={key}
+              prefix={key}
+              currentPath={addToPath(currentPath, key)}
+              highlightedPaths={highlightedPaths}
+            />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  // Primitive leafs
+  return (
+    <div style={{ backgroundColor: errorMessage ? "pink" : "inherit" }}>
+      {prefixDisplay}
+      {formatPrimitiveData(data)} [{errorMessage}]
+    </div>
+  );
+};
+
+const formatPrimitiveData = (data: unknown) =>
+  typeof data === "string" ? `\"${data}\"` : String(data);
+
+const isObject = (data: unknown): data is Record<string, unknown> =>
+  typeof data === "object" && data !== null;
+
+const addToPath = (existingPath: string, newSegment: string) =>
+  existingPath ? `${existingPath}.${newSegment}` : newSegment;

--- a/packages/groqd-playground/src/components/JSONExplorer.tsx
+++ b/packages/groqd-playground/src/components/JSONExplorer.tsx
@@ -138,7 +138,7 @@ const formatPrimitiveData = (data: unknown) =>
   typeof data === "string" ? `\"${data}\"` : String(data);
 
 const isObject = (data: unknown): data is Record<string, unknown> =>
-  typeof data === "object" && data !== null;
+  typeof data === "object" && data !== null && !Array.isArray(data);
 
 const addToPath = (existingPath: string, newSegment: string) =>
   existingPath ? `${existingPath}.${newSegment}` : newSegment;

--- a/packages/groqd-playground/src/components/ShareUrlField.tsx
+++ b/packages/groqd-playground/src/components/ShareUrlField.tsx
@@ -11,7 +11,7 @@ import {
   Tooltip,
 } from "@sanity/ui";
 import { CopyIcon } from "@sanity/icons";
-import { useCopyUrlAndNotify } from "../hooks/copyUrl";
+import { useCopyDataAndNotify } from "../hooks/copyDataToClipboard";
 
 type ShareUrlFieldProps = {
   url: string;
@@ -26,7 +26,7 @@ export const ShareUrlField = ({
   column = 4,
   notificationMessage = "Copied URL to clipboard!",
 }: ShareUrlFieldProps) => {
-  const copyUrl = useCopyUrlAndNotify(notificationMessage);
+  const copyUrl = useCopyDataAndNotify(notificationMessage);
   const handleCopyUrl = () => copyUrl(url);
 
   return (

--- a/packages/groqd-playground/src/hooks/copyDataToClipboard.ts
+++ b/packages/groqd-playground/src/hooks/copyDataToClipboard.ts
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { useToast } from "@sanity/ui";
 
-export const useCopyUrlAndNotify = (message: string) => {
+export const useCopyDataAndNotify = (message: string) => {
   const toast = useToast();
 
   return React.useCallback(

--- a/packages/groqd/src/schemas.test.ts
+++ b/packages/groqd/src/schemas.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, expectTypeOf, it } from "vitest";
 import { runPokemonQuery, runUserQuery } from "../test-utils/runQuery";
 import { q } from "./index";
 import invariant from "tiny-invariant";
+import { z } from "zod";
 
 describe("string", () => {
   it("will generate a string type", async () => {

--- a/packages/groqd/src/schemas.test.ts
+++ b/packages/groqd/src/schemas.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, expectTypeOf, it } from "vitest";
 import { runPokemonQuery, runUserQuery } from "../test-utils/runQuery";
 import { q } from "./index";
 import invariant from "tiny-invariant";
-import { z } from "zod";
 
 describe("string", () => {
   it("will generate a string type", async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,6 +139,9 @@ importers:
       '@types/react':
         specifier: ^18.0.35
         version: 18.0.35
+      '@types/styled-components':
+        specifier: ^5.1.26
+        version: 5.1.26
       tsup:
         specifier: ^6.7.0
         version: 6.7.0(typescript@4.9.5)


### PR DESCRIPTION
Initial work for JSON inspector. I'm sure it'll break and we can iterate. Right now, showing successful parsed response, and raw response for failed parsing. Errors are highlighted. Can copy response to clipboard (as JSON). Will follow up with ability to click an error from the top panel and have it scroll into view in the JSON explorer.

![image](https://user-images.githubusercontent.com/12721310/233688878-e1589de1-d6d3-4b92-b070-9aa652f867de.png)
