### PR TITLE
Add `.filter` method to `EntityQuery`.

### DIFF
--- a/.changeset/soft-fishes-approve.md
+++ b/.changeset/soft-fishes-approve.md
@@ -1,0 +1,5 @@
+---
+"groqd": patch
+---
+
+Add .filter() method to EntityQuery

--- a/packages/groqd/src/builder.test.ts
+++ b/packages/groqd/src/builder.test.ts
@@ -263,7 +263,7 @@ describe("grabOne$", () => {
   });
 });
 
-describe("UnknownResult.filter/ArrayResult.filter", () => {
+describe("UnknownResult.filter/ArrayResult.filter/EntityQuery.filter", () => {
   it("applies simple filter appropriately to UnknownResult, returning unknown array", async () => {
     const { query, data } = await runPokemonQuery(
       q("*").filter("_type == 'pokemon'")
@@ -308,6 +308,22 @@ describe("UnknownResult.filter/ArrayResult.filter", () => {
     expect(
       schema2 instanceof z.ZodArray && schema2.element instanceof z.ZodUnknown
     );
+  });
+
+  it("works on EntityQuery", async () => {
+    const { data } = await runPokemonQuery(
+      q("*")
+        .filterByType("pokemon")
+        .slice(0)
+        .grabOne("types", q.unknown())
+        .filter()
+        .grab$({
+          _ref: q.string(),
+        })
+    );
+
+    invariant(data);
+    expectTypeOf(data).toEqualTypeOf<{ _ref: string }[]>();
   });
 });
 

--- a/packages/groqd/src/builder.ts
+++ b/packages/groqd/src/builder.ts
@@ -23,6 +23,14 @@ export class EntityQuery<T extends z.ZodTypeAny> extends BaseQuery<T> {
     super(payload);
   }
 
+  filter(filterValue = ""): ArrayQuery<T> {
+    this.query += `[${filterValue}]`;
+    return new ArrayQuery({
+      query: this.query,
+      schema: z.array(this.schema),
+    });
+  }
+
   select<Conditions extends ConditionRecord>(
     s: Conditions
   ): EntityQuery<Spread<SelectSchemaType<Conditions>>>;


### PR DESCRIPTION
Adds `.filter` method to `EntityQuery`, since there doesn't appear to be a strong reason not to have that available.