### PR TITLE
Playground dates

### DIFF
--- a/.changeset/heavy-jeans-film.md
+++ b/.changeset/heavy-jeans-film.md
@@ -1,0 +1,5 @@
+---
+"groqd-playground": patch
+---
+
+Fix Date display in playground

--- a/packages/groqd-playground/src/components/JSONExplorer.tsx
+++ b/packages/groqd-playground/src/components/JSONExplorer.tsx
@@ -134,11 +134,17 @@ const JSONExplorerDisplay = ({
   );
 };
 
-const formatPrimitiveData = (data: unknown) =>
-  typeof data === "string" ? `\"${data}\"` : String(data);
+const formatPrimitiveData = (data: unknown) => {
+  if (typeof data === "string") return `\"${data}\"`;
+  if (data instanceof Date) return `(Date) ${data}`;
+  return String(data);
+};
 
 const isObject = (data: unknown): data is Record<string, unknown> =>
-  typeof data === "object" && data !== null && !Array.isArray(data);
+  typeof data === "object" &&
+  data !== null &&
+  !Array.isArray(data) &&
+  !(data instanceof Date);
 
 const addToPath = (existingPath: string, newSegment: string) =>
   existingPath ? `${existingPath}.${newSegment}` : newSegment;


### PR DESCRIPTION
I missed `Date` as an object type, so dates were showing as objects in the playground. This PR handles Dates separately.