### PR TITLE
Playground: Copy Query

### DIFF
--- a/.changeset/curly-rules-grab.md
+++ b/.changeset/curly-rules-grab.md
@@ -1,0 +1,6 @@
+---
+"groqd-playground-editor": patch
+"groqd-playground": patch
+---
+
+Changed default code in editor, added functionality to copy query to clipboard

--- a/packages/groqd-playground/src/components/Playground.styled.tsx
+++ b/packages/groqd-playground/src/components/Playground.styled.tsx
@@ -15,3 +15,13 @@ export const ErrorLineItem = styled(Box)`
     }
   }
 `;
+
+export const CopyQueryButton = styled.button`
+  all: unset;
+  cursor: pointer;
+  &:focus {
+    box-shadow: inset 0 0 0 1px var(--card-border-color), 0 0 0 1px #fff,
+      0 0 0 3px var(--card-focus-ring-color);
+    border-radius: 0.1875rem;
+  }
+`;

--- a/packages/groqd-playground/src/components/Playground.tsx
+++ b/packages/groqd-playground/src/components/Playground.tsx
@@ -26,7 +26,7 @@ import { ShareUrlField } from "./ShareUrlField";
 import { useCopyDataAndNotify } from "../util/copyDataToClipboard";
 import { emitInit, emitReset } from "../util/messaging";
 import { JSONExplorer } from "./JSONExplorer";
-import { ErrorLineItem } from "./Playground.styled";
+import { CopyQueryButton, ErrorLineItem } from "./Playground.styled";
 
 export default function GroqdPlayground({ tool }: GroqdPlaygroundProps) {
   const [
@@ -445,12 +445,9 @@ export default function GroqdPlayground({ tool }: GroqdPlaygroundProps) {
                     <Label muted>
                       Query{"  "}
                       {query.query && (
-                        <span
-                          style={{ cursor: "pointer" }}
-                          onClick={handleCopyQuery}
-                        >
+                        <CopyQueryButton onClick={handleCopyQuery} tabIndex={0}>
                           (Copy to clipboard)
-                        </span>
+                        </CopyQueryButton>
                       )}
                     </Label>
                   </Box>

--- a/packages/groqd-playground/src/components/Playground.tsx
+++ b/packages/groqd-playground/src/components/Playground.tsx
@@ -18,7 +18,7 @@ import { z } from "zod";
 import * as q from "groqd";
 import { BaseQuery } from "groqd/src/baseQuery";
 import Split from "@uiw/react-split";
-import { PlayIcon, ResetIcon } from "@sanity/icons";
+import { ClipboardIcon, CopyIcon, PlayIcon, ResetIcon } from "@sanity/icons";
 import { GroqdPlaygroundProps } from "../types";
 import { useDatasets } from "../util/useDatasets";
 import { API_VERSIONS, DEFAULT_API_VERSION, STORAGE_KEYS } from "../consts";
@@ -70,6 +70,7 @@ export default function GroqdPlayground({ tool }: GroqdPlaygroundProps) {
     []
   );
   const copyShareUrl = useCopyDataAndNotify("Copied share URL to clipboard!");
+  const copyQueryUrl = useCopyDataAndNotify("Copied Query to clipboard!");
   const windowHref = window.location.href;
 
   // Configure client
@@ -237,6 +238,8 @@ export default function GroqdPlayground({ tool }: GroqdPlaygroundProps) {
   const handleReset = () => {
     iframeRef.current && emitReset(iframeRef.current, EDITOR_ORIGIN);
   };
+
+  const handleCopyQuery = () => query.query && copyQueryUrl(query.query);
 
   const handleEditorResize = () => {
     const container = editorContainer.current;
@@ -439,7 +442,17 @@ export default function GroqdPlayground({ tool }: GroqdPlaygroundProps) {
               <Stack space={3}>
                 <Box>
                   <Box paddingX={3} marginBottom={1}>
-                    <Label muted>Query</Label>
+                    <Label muted>
+                      Query{"  "}
+                      {query.query && (
+                        <span
+                          style={{ cursor: "pointer" }}
+                          onClick={handleCopyQuery}
+                        >
+                          (Copy to clipboard)
+                        </span>
+                      )}
+                    </Label>
                   </Box>
                   <Flex padding={3} paddingBottom={4} overflow="auto">
                     <Code language="text">{query.query}</Code>
@@ -497,7 +510,7 @@ export default function GroqdPlayground({ tool }: GroqdPlaygroundProps) {
 const EDITOR_URL =
   process.env.SANITY_STUDIO_GROQD_PLAYGROUND_ENV === "development"
     ? "http://localhost:3069"
-    : "https://unpkg.com/groqd-playground-editor@0.0.4/build/index.html";
+    : "https://unpkg.com/groqd-playground-editor@0.0.5/build/index.html";
 const EDITOR_ORIGIN = new URL(EDITOR_URL).origin;
 
 type Params = Record<string, string | number>;

--- a/packages/groqd-playground/src/components/Playground.tsx
+++ b/packages/groqd-playground/src/components/Playground.tsx
@@ -18,13 +18,13 @@ import { z } from "zod";
 import * as q from "groqd";
 import { BaseQuery } from "groqd/src/baseQuery";
 import Split from "@uiw/react-split";
-import { ClipboardIcon, CopyIcon, PlayIcon, ResetIcon } from "@sanity/icons";
+import { PlayIcon, ResetIcon } from "@sanity/icons";
 import { GroqdPlaygroundProps } from "../types";
 import { useDatasets } from "../util/useDatasets";
 import { API_VERSIONS, DEFAULT_API_VERSION, STORAGE_KEYS } from "../consts";
 import { ShareUrlField } from "./ShareUrlField";
 import { useCopyDataAndNotify } from "../util/copyDataToClipboard";
-import { emitReset, emitInit } from "../util/messaging";
+import { emitInit, emitReset } from "../util/messaging";
 import { JSONExplorer } from "./JSONExplorer";
 import { ErrorLineItem } from "./Playground.styled";
 

--- a/packages/playground-editor/src/App.tsx
+++ b/packages/playground-editor/src/App.tsx
@@ -185,12 +185,22 @@ const runCode = async (
 };
 
 // Initial code, will likely change in the future.
-const DEFAULT_INIT_CODE = [
-  `import { runQuery } from "playground";`,
-  `import { q } from "groqd";`,
-  "",
-  `runQuery(\n\tq("*")\n\t.filter()\n\t.slice(0, 10)\n\t.grab$({\n\t\t_id: q.string()\n\t})\n);`,
-].join("\n");
+const DEFAULT_INIT_CODE = `
+import { runQuery } from "playground";
+import { q } from "groqd";
+
+runQuery(
+  q("*")
+    .filter()
+    .slice(0, 10)
+    .grab$({
+      _id: q.string()
+    }),
+	// params (optional)
+  {}
+);
+
+`.trim();
 
 // Adding in groqd types, and our custom playground.runQuery helper.
 const extraLibs = [


### PR DESCRIPTION
Changes default editor code (to show how query params can be used), and add functionality to copy query to clipboard.