### PR TITLE
`.deref` on EntityQuery

### DIFF
--- a/.changeset/rude-bags-listen.md
+++ b/.changeset/rude-bags-listen.md
@@ -1,0 +1,5 @@
+---
+"groqd": patch
+---
+
+Move .deref from UnknownQuery to EntityQuery so that one can deref on EntityQuery if need be.

--- a/packages/groqd/src/builder.ts
+++ b/packages/groqd/src/builder.ts
@@ -86,6 +86,13 @@ export class EntityQuery<T extends z.ZodTypeAny> extends BaseQuery<T> {
       schema: nullToUndefined(fieldSchema),
     });
   }
+
+  deref(): UnknownQuery {
+    return new UnknownQuery({
+      ...this.value(),
+      query: this.query + "->",
+    });
+  }
 }
 
 /**
@@ -106,11 +113,6 @@ export class UnknownQuery extends EntityQuery<z.ZodUnknown> {
 
   filterByType(filterTypeValue: string) {
     return this.filter(`_type == '${filterTypeValue}'`);
-  }
-
-  deref() {
-    this.query += "->";
-    return this;
   }
 }
 


### PR DESCRIPTION
Just pulls `.deref` "down" from `UnknownQuery` to `EntityQuery` so that you can deref `EntityQuery` as well as `UnknownQuery` (we've seen a need for this, in particular when you have an `EntityQuery<unknown>` which is effectively identical to `UnknownQuery`).