### PR TITLE
Default schema for `.grabOne`

### DIFF
--- a/.changeset/sharp-pans-sort.md
+++ b/.changeset/sharp-pans-sort.md
@@ -1,0 +1,5 @@
+---
+"groqd": patch
+---
+
+Default z.unknown() schema for .grabOne/.grabOne$ methods

--- a/packages/groqd/src/builder.test.ts
+++ b/packages/groqd/src/builder.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, expectTypeOf, it } from "vitest";
 import { q } from "./index";
-import { z } from "zod";
+import { unknown, z } from "zod";
 import { runPokemonQuery, runUserQuery } from "../test-utils/runQuery";
 import invariant from "tiny-invariant";
 
@@ -260,6 +260,25 @@ describe("grabOne$", () => {
     expectTypeOf(data).toEqualTypeOf<(string | undefined)[]>();
     expect(data[0]).toBeUndefined();
     expect(data[1]).toBeUndefined();
+  });
+
+  it("defaults to unknown() if no second arg provided on EntityQuery", async () => {
+    const { data } = await runPokemonQuery(
+      q("*").filterByType("pokemon").slice(0).grabOne$("name")
+    );
+
+    expectTypeOf(data).toEqualTypeOf<unknown>();
+    expect(data).toEqual("Bulbasaur");
+  });
+
+  it("defaults to unknown() if no second arg provided on ArrayQuery", async () => {
+    const { data } = await runPokemonQuery(
+      q("*").filterByType("pokemon").slice(0, 1).grabOne$("name")
+    );
+
+    invariant(data);
+    expectTypeOf(data).toEqualTypeOf<unknown[]>();
+    expect(data).toEqual(["Bulbasaur", "Ivysaur"]);
   });
 });
 
@@ -529,6 +548,25 @@ describe("ArrayResult.grabOne/EntityResult.grabOne", () => {
     expect(query).toBe(`*[_type == 'pokemon'][0].name`);
     expectTypeOf(data).exclude(undefined).toEqualTypeOf<string>();
     expect(data).toBe("Bulbasaur");
+  });
+
+  it("defaults to unknown() if no second arg provided on EntityQuery", async () => {
+    const { data } = await runPokemonQuery(
+      q("*").filterByType("pokemon").slice(0).grabOne("name")
+    );
+
+    expectTypeOf(data).toEqualTypeOf<unknown>();
+    expect(data).toEqual("Bulbasaur");
+  });
+
+  it("defaults to unknown() if no second arg provided on ArrayQuery", async () => {
+    const { data } = await runPokemonQuery(
+      q("*").filterByType("pokemon").slice(0, 1).grabOne("name")
+    );
+
+    invariant(data);
+    expectTypeOf(data).toEqualTypeOf<unknown[]>();
+    expect(data).toEqual(["Bulbasaur", "Ivysaur"]);
   });
 });
 

--- a/packages/groqd/src/builder.test.ts
+++ b/packages/groqd/src/builder.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, expectTypeOf, it } from "vitest";
 import { q } from "./index";
-import { unknown, z } from "zod";
+import { z } from "zod";
 import { runPokemonQuery, runUserQuery } from "../test-utils/runQuery";
 import invariant from "tiny-invariant";
 

--- a/packages/groqd/src/builder.ts
+++ b/packages/groqd/src/builder.ts
@@ -67,23 +67,27 @@ export class EntityQuery<T extends z.ZodTypeAny> extends BaseQuery<T> {
     );
   }
 
+  grabOne(name: string): EntityQuery<z.ZodUnknown>;
   grabOne<GrabOneType extends z.ZodType>(
     name: string,
     fieldSchema: GrabOneType
-  ) {
-    return new EntityQuery<GrabOneType>({
+  ): EntityQuery<GrabOneType>;
+  grabOne(name: string, fieldSchema?: z.ZodType) {
+    return new EntityQuery({
       query: this.query + `.${name}`,
-      schema: fieldSchema,
+      schema: fieldSchema || z.unknown(),
     });
   }
 
+  grabOne$(name: string): EntityQuery<z.ZodEffects<z.ZodUnknown>>;
   grabOne$<GrabOneType extends z.ZodType>(
     name: string,
     fieldSchema: GrabOneType
-  ) {
-    return new EntityQuery<z.ZodEffects<GrabOneType>>({
+  ): EntityQuery<z.ZodEffects<GrabOneType>>;
+  grabOne$(name: string, fieldSchema?: z.ZodType) {
+    return new EntityQuery({
       query: this.query + `.${name}`,
-      schema: nullToUndefined(fieldSchema),
+      schema: nullToUndefined(fieldSchema || z.unknown()),
     });
   }
 }
@@ -169,23 +173,27 @@ export class ArrayQuery<T extends z.ZodTypeAny> extends BaseQuery<
     );
   }
 
+  grabOne(name: string): ArrayQuery<z.ZodUnknown>;
   grabOne<GrabOneType extends z.ZodType>(
     name: string,
     fieldSchema: GrabOneType
-  ) {
-    return new ArrayQuery<GrabOneType>({
+  ): ArrayQuery<GrabOneType>;
+  grabOne(name: string, fieldSchema?: z.ZodType) {
+    return new ArrayQuery({
       query: this.query + `.${name}`,
-      schema: z.array(fieldSchema),
+      schema: z.array(fieldSchema || z.unknown()),
     });
   }
 
+  grabOne$(name: string): ArrayQuery<z.ZodEffects<z.ZodUnknown>>;
   grabOne$<GrabOneType extends z.ZodType>(
     name: string,
     fieldSchema: GrabOneType
-  ) {
-    return new ArrayQuery<z.ZodEffects<GrabOneType>>({
+  ): ArrayQuery<z.ZodEffects<GrabOneType>>;
+  grabOne$(name: string, fieldSchema?: z.ZodType) {
+    return new ArrayQuery({
       query: this.query + `.${name}`,
-      schema: z.array(nullToUndefined(fieldSchema)),
+      schema: z.array(nullToUndefined(fieldSchema || z.unknown())),
     });
   }
 


### PR DESCRIPTION
Uses `z.unknown()` as default schema for `.grabOne/.grabOne$` if none provided.