### PR TITLE
Safely access `process.env.SANITY_STUDIO_...`

### DIFF
--- a/.changeset/flat-rockets-turn.md
+++ b/.changeset/flat-rockets-turn.md
@@ -1,0 +1,5 @@
+---
+"groqd-playground": patch
+---
+
+Safely access process.env.SANITY*STUDIO*... to support older versions of SS3.

--- a/packages/groqd-playground/src/components/Playground.tsx
+++ b/packages/groqd-playground/src/components/Playground.tsx
@@ -505,7 +505,8 @@ export default function GroqdPlayground({ tool }: GroqdPlaygroundProps) {
 }
 
 const EDITOR_URL =
-  process.env.SANITY_STUDIO_GROQD_PLAYGROUND_ENV === "development"
+  typeof process !== "undefined" &&
+  process?.env?.SANITY_STUDIO_GROQD_PLAYGROUND_ENV === "development"
     ? "http://localhost:3069"
     : "https://unpkg.com/groqd-playground-editor@0.0.5/build/index.html";
 const EDITOR_ORIGIN = new URL(EDITOR_URL).origin;


### PR DESCRIPTION
See changeset entry for description