### PR TITLE
Raw response on `GroqdParseError`

### DIFF
--- a/.changeset/cuddly-needles-cry.md
+++ b/.changeset/cuddly-needles-cry.md
@@ -1,0 +1,5 @@
+---
+"groqd": patch
+---
+
+Add rawResponse on GroqdParseError

--- a/docs/utility-methods.md
+++ b/docs/utility-methods.md
@@ -49,6 +49,8 @@ Error parsing `result[0].things[0].name`: Expected string, received number.
 ```
 
 You can import the `GroqdParseError` class directly from `groqd` if you need it for `instanceof` checks.
+
+The `GroqdParseError` class contains a `zodError` field to view the full Zod error, and a `.rawResponse` field so you can view the raw response that failed validation (helpful for debugging).
 :::
 
 ## `nullToUndefined`

--- a/packages/groqd/src/makeSafeQueryRunner.test.ts
+++ b/packages/groqd/src/makeSafeQueryRunner.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi } from "vitest";
 import { GroqdParseError, q } from "./index";
 import { makeSafeQueryRunner } from "./makeSafeQueryRunner";
+import { runPokemonQuery } from "../test-utils/runQuery";
+import invariant from "tiny-invariant";
 
 describe("makeSafeQueryRunner", () => {
   it("should create a query runner with single argument", async () => {
@@ -73,5 +75,14 @@ describe("makeSafeQueryRunner", () => {
         `Error parsing:\n\t\`result[0].things[0].name\`: Expected string, received number\n\t\`result[0].foo\`: Invalid literal value, expected "baz"`
       );
     }
+  });
+
+  it("should contain raw response on error", async () => {
+    const { error } = await runPokemonQuery(
+      q("*").filterByType("pokemon").slice(0, 1).grabOne("name", q.number())
+    );
+
+    invariant(error instanceof GroqdParseError);
+    expect(error.rawResponse).toEqual(["Bulbasaur", "Ivysaur"]);
   });
 });

--- a/packages/groqd/src/makeSafeQueryRunner.ts
+++ b/packages/groqd/src/makeSafeQueryRunner.ts
@@ -14,15 +14,17 @@ export const makeSafeQueryRunner =
       try {
         return schema.parse(res);
       } catch (e) {
-        if (e instanceof z.ZodError) throw new GroqdParseError(e);
+        if (e instanceof z.ZodError) throw new GroqdParseError(e, res);
         throw e;
       }
     });
 
 export class GroqdParseError extends Error {
   readonly zodError: z.ZodError;
+  readonly rawResponse: unknown;
+
   // zodError: z.ZodError;
-  constructor(public readonly err: z.ZodError) {
+  constructor(public readonly err: z.ZodError, rawResponse: unknown) {
     const errorMessages = err.errors.map(
       (e) =>
         `\t\`result${e.path.reduce((acc, el) => {
@@ -35,6 +37,7 @@ export class GroqdParseError extends Error {
 
     super(`Error parsing:\n${errorMessages.join("\n")}`);
     this.zodError = err;
+    this.rawResponse = rawResponse;
   }
 }
 


### PR DESCRIPTION
Tack the raw response onto `GroqdParseError` to help with debugging validation failures.