### PR TITLE
Arcade: Run Button & collapse animation

### DIFF
--- a/website/src/arcade/Arcade.tsx
+++ b/website/src/arcade/Arcade.tsx
@@ -19,6 +19,8 @@ import { ArcadeResponseView } from "@site/src/arcade/ArcadeResponseView";
 import lzstring from "lz-string";
 import { runCodeEmitter } from "@site/src/arcade/eventEmitters";
 import { DefaultToastOptions, Toaster } from "react-hot-toast";
+import { HiPlay } from "react-icons/hi";
+import clsx from "clsx";
 
 export function Arcade() {
   const [
@@ -45,6 +47,10 @@ export function Arcade() {
     setDatasetPreset(dataset);
     MODELS.ts.setValue(code);
 
+    runCodeEmitter.emit(true);
+  };
+
+  const handleRun = () => {
     runCodeEmitter.emit(true);
   };
 
@@ -94,6 +100,20 @@ export function Arcade() {
             <div className="h-full flex flex-col">
               <div className="relative flex-1">
                 <ArcadeEditor dispatch={dispatch} />
+                <div className="absolute right-0 bottom-0 p-4">
+                  <button
+                    className={clsx(
+                      "inline-flex items-center px-5 py-2 gap-3",
+                      "bg-gray-50 border-none text-xl rounded shadow-sm hover:shadow-md font-bold text-gray-700",
+                      "cursor-pointer bg-gradient-to-tr from-green-200 to-green-100 hover:bg-green-200",
+                      "transition-colors transition-shadow duration-150"
+                    )}
+                    onClick={handleRun}
+                  >
+                    <span>Run</span>
+                    <HiPlay className="text-2xl text-green-600" />
+                  </button>
+                </div>
               </div>
               <ArcadeQueryDisplay query={query.query} />
             </div>

--- a/website/src/arcade/Arcade.tsx
+++ b/website/src/arcade/Arcade.tsx
@@ -100,20 +100,18 @@ export function Arcade() {
             <div className="h-full flex flex-col">
               <div className="relative flex-1">
                 <ArcadeEditor dispatch={dispatch} />
-                <div className="absolute right-0 bottom-0 p-4">
-                  <button
-                    className={clsx(
-                      "inline-flex items-center px-5 py-2 gap-3",
-                      "bg-gray-50 border-none text-xl rounded shadow-sm hover:shadow-md font-bold text-gray-700",
-                      "cursor-pointer bg-gradient-to-tr from-green-200 to-green-100 hover:bg-green-200",
-                      "transition-colors transition-shadow duration-150"
-                    )}
-                    onClick={handleRun}
-                  >
-                    <span>Run</span>
-                    <HiPlay className="text-2xl text-green-600" />
-                  </button>
-                </div>
+                <button
+                  className={clsx(
+                    "absolute right-8 bottom-5 inline-flex items-center px-5 py-2 gap-3",
+                    "bg-gray-50 border-none text-lg rounded shadow-sm hover:shadow-md font-bold text-gray-700",
+                    "cursor-pointer bg-gradient-to-tr from-green-200 to-green-100 hover:bg-green-200",
+                    "transition-colors transition-shadow duration-150"
+                  )}
+                  onClick={handleRun}
+                >
+                  <span>Run</span>
+                  <HiPlay className="text-2xl text-green-600" />
+                </button>
               </div>
               <ArcadeQueryDisplay query={query.query} />
             </div>

--- a/website/src/arcade/Arcade.tsx
+++ b/website/src/arcade/Arcade.tsx
@@ -96,22 +96,23 @@ export function Arcade() {
           <ArcadeSection
             title="Query Code"
             subtitle="Your code to run a GROQD query."
+            headerRightContent={
+              <button
+                className={clsx(
+                  "group border-none rounded-md flex items-center gap-3 px-4 py-1",
+                  "text-base font-bold cursor-pointer text-gray-700",
+                  "bg-gray-50 hover:bg-gray-200 transition-colors duration-150"
+                )}
+                onClick={handleRun}
+              >
+                <span>Run</span>
+                <HiPlay className="text-3xl opacity-90 group-hover:opacity-100 text-green-600 transition-colors transition-opacity duration-150" />
+              </button>
+            }
           >
             <div className="h-full flex flex-col">
               <div className="relative flex-1">
                 <ArcadeEditor dispatch={dispatch} />
-                <button
-                  className={clsx(
-                    "absolute right-8 bottom-5 inline-flex items-center px-5 py-2 gap-3",
-                    "bg-gray-50 border-none text-lg rounded shadow-sm hover:shadow-md font-bold text-gray-700",
-                    "cursor-pointer bg-gradient-to-tr from-green-200 to-green-100 hover:bg-green-200",
-                    "transition-colors transition-shadow duration-150"
-                  )}
-                  onClick={handleRun}
-                >
-                  <span>Run</span>
-                  <HiPlay className="text-2xl text-green-600" />
-                </button>
               </div>
               <ArcadeQueryDisplay query={query.query} />
             </div>

--- a/website/src/arcade/ArcadeEditor.tsx
+++ b/website/src/arcade/ArcadeEditor.tsx
@@ -15,10 +15,7 @@ import { ARCADE_STORAGE_KEYS } from "@site/src/arcade/consts";
 import lzstring from "lz-string";
 import { createTwoslashInlayProvider } from "../../../shared/util/twoslashInlays";
 import has from "lodash.has";
-import {
-  runCodeEmitter,
-  runQueryEmitter,
-} from "@site/src/arcade/eventEmitters";
+import { runCodeEmitter } from "@site/src/arcade/eventEmitters";
 import { registerEditorShortcuts } from "@site/src/arcade/editorShortcuts";
 import toast from "react-hot-toast";
 
@@ -97,11 +94,8 @@ export const ArcadeEditor = ({ dispatch }: ArcadeEditorProps) => {
       }
     );
 
-    const runQueryEmitterHandle = runQueryEmitter.subscribe(runQuery);
-
     return () => {
       runCodeEmitterHandle.unsubscribe();
-      runQueryEmitterHandle.unsubscribe();
     };
   }, []);
 

--- a/website/src/arcade/ArcadeSection.tsx
+++ b/website/src/arcade/ArcadeSection.tsx
@@ -3,20 +3,25 @@ import * as React from "react";
 type ArcadeSectionProps = {
   title: string;
   subtitle?: string;
+  headerRightContent?: JSX.Element;
 };
 
 export function ArcadeSection({
   title,
   subtitle,
+  headerRightContent,
   children,
 }: React.PropsWithChildren<ArcadeSectionProps>) {
   return (
     <div className="w-full border border-solid border-gray-200 rounded overflow-hidden flex flex-col h-full overflow-hidden">
-      <div className="p-4">
-        <div className="text-base font-bold leading-none text-gray-700 mb-0.5">
-          {title}
+      <div className="p-4 flex items-center justify-between">
+        <div>
+          <div className="text-base font-bold leading-none text-gray-700 mb-0.5">
+            {title}
+          </div>
+          {subtitle && <div className="text-gray-800 text-sm">{subtitle}</div>}
         </div>
-        {subtitle && <div className="text-gray-800 text-sm">{subtitle}</div>}
+        {headerRightContent}
       </div>
       <div className="flex-1 relative">{children}</div>
     </div>

--- a/website/src/arcade/JSONExplorer.tsx
+++ b/website/src/arcade/JSONExplorer.tsx
@@ -152,6 +152,7 @@ function Collapsible({
           maxHeight += el.scrollHeight;
       });
 
+      // Take into account nested collapsed collapsibles so transition is always 300ms
       div.style.setProperty(
         "--duration",
         `${(maxHeight / initMaxHeight) * TRANSITION_DURATION}ms`

--- a/website/src/arcade/JSONExplorer.tsx
+++ b/website/src/arcade/JSONExplorer.tsx
@@ -131,10 +131,40 @@ function Collapsible({
   id?: string;
 }>) {
   const [isExpanded, setIsExpanded] = React.useState(true);
+  const bodyWrapper = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    const div = bodyWrapper.current;
+    if (!div) return;
+
+    const TRANSITION_DURATION = 300; // ms
+
+    if (isExpanded) {
+      const initMaxHeight = div.scrollHeight;
+
+      /**
+       * We might have nested collapsibles that are collapsed – we need to take those into account.
+       * Loop through and grab scrollHeight of each nested collapsed collapsible, so we can take that into account.
+       */
+      let maxHeight = initMaxHeight;
+      div.querySelectorAll("div.__collapsible_body").forEach((el) => {
+        if (el instanceof HTMLDivElement && el.style.maxHeight === "0px")
+          maxHeight += el.scrollHeight;
+      });
+
+      div.style.setProperty(
+        "--duration",
+        `${(maxHeight / initMaxHeight) * TRANSITION_DURATION}ms`
+      );
+      div.style.maxHeight = maxHeight + "px";
+    } else {
+      div.style.setProperty("--duration", `${TRANSITION_DURATION}ms`);
+      div.style.maxHeight = "0px";
+    }
+  }, [isExpanded]);
 
   return (
     <Stack
-      space="2"
       className={clsx("rounded py-0.5", !!errorMessage && ERROR_CLASS)}
       id={id}
     >
@@ -149,7 +179,11 @@ function Collapsible({
           <div>{title}</div>
         </Stack>
       </LineItem>
-      <div style={{ height: isExpanded ? "auto" : 0, overflow: "hidden" }}>
+      <div
+        ref={bodyWrapper}
+        className="overflow-hidden transition-all duration-[var(--duration)] will-change-[maxHeight] __collapsible_body"
+      >
+        <div className="h-2" />
         {children}
       </div>
     </Stack>

--- a/website/src/arcade/eventEmitters.ts
+++ b/website/src/arcade/eventEmitters.ts
@@ -23,8 +23,3 @@ class SimpleEventEmitter<S> {
  * Trigger code run from anywhere.
  */
 export const runCodeEmitter = new SimpleEventEmitter<boolean>();
-
-/**
- * Trigger query run from anywhere
- */
-export const runQueryEmitter = new SimpleEventEmitter();


### PR DESCRIPTION
Adds in the missing "Run" button. For now, I put it in the header of the Code card because:

- i think it avoids adding depth/clutter
- when editing code, user's cursor will likely be closer to the top of the code editor – so having the run button in the top feels a bit more comfy for the user.

We can tweak this later on, I just wanted to get a run button in there.

<img width="812" alt="image" src="https://user-images.githubusercontent.com/12721310/236250474-dbd6af96-e6db-4878-9c5e-6962f41b78df.png">

I also added in some logic for JSON explorer collapse animation.


https://user-images.githubusercontent.com/12721310/236260618-3a7738f6-85b5-4bea-b961-6a3c3dc33d48.mp4


