### PR TITLE
feat: accept sanity file asset as an image type

### DIFF
--- a/.changeset/large-pets-argue.md
+++ b/.changeset/large-pets-argue.md
@@ -1,0 +1,5 @@
+---
+"groqd": patch
+---
+
+ability for sanityImage schema to handle file assets

--- a/packages/groqd/src/sanityImage.test.ts
+++ b/packages/groqd/src/sanityImage.test.ts
@@ -202,6 +202,45 @@ describe("sanityImage", () => {
     expect(im.asset._updatedAt === "2022-12-12T19:45:48Z").toBeTruthy();
   });
 
+  it("can query fetch base file asset data", async () => {
+    const { query, data } = await runPokemonQuery(
+      q("*")
+        .filter("_type == 'pokemon'")
+        .slice(0, 1)
+        .grab({
+          name: q.string(),
+          statsSheet: sanityImage("statsSheet", {
+            withAsset: ["base"],
+          }),
+        })
+    );
+
+    expect(query).toBe(
+      `*[_type == 'pokemon'][0..1]{name, "statsSheet": statsSheet{_key, _type, "asset": asset->{_id, _type, _rev, extension, mimeType, originalFilename, path, sha1hash, size, url, _updatedAt}}}`
+    );
+    const im = data?.[0]?.statsSheet;
+    invariant(im);
+    expect(im.asset._id === "file-1-pdf").toBeTruthy();
+    expect(im.asset._type === "sanity.fileAsset").toBeTruthy();
+    expect(im.asset._rev === "X6HgJNl2Cktkcl6TQwg3gv").toBeTruthy();
+    expect(im.asset.extension === "pdf").toBeTruthy();
+    expect(im.asset.mimeType === "application/pdf").toBeTruthy();
+    expect(im.asset.originalFilename === "pokemon-1.pdf").toBeTruthy();
+    expect(
+      im.asset.path ===
+        "files/nfttuagc/production/ed158069c3b44124a310d7a107998e06bf12e90e-1000x500.pdf"
+    ).toBeTruthy();
+    expect(
+      im.asset.sha1hash === "ed158069c3b44124a310d7a107998e06bf12e90e"
+    ).toBeTruthy();
+    expect(im.asset.size === 37594).toBeTruthy();
+    expect(
+      im.asset.url ===
+        "https://cdn.sanity.io/files/nfttuagc/production/ed158069c3b44124a310d7a107998e06bf12e90e-1000x500.pdf"
+    ).toBeTruthy();
+    expect(im.asset._updatedAt === "2022-12-12T19:45:48Z").toBeTruthy();
+  });
+
   it("can query fetch image asset data with dimensions metadata", async () => {
     const { query, data } = await runPokemonQuery(
       q("*")

--- a/packages/groqd/src/sanityImage.ts
+++ b/packages/groqd/src/sanityImage.ts
@@ -36,7 +36,10 @@ const refBase = {
 
 const dereffedAssetBaseFields = {
   _id: schemas.string(),
-  _type: schemas.literal("sanity.imageAsset"),
+  _type: schemas.union([
+    schemas.literal("sanity.imageAsset"),
+    schemas.literal("sanity.fileAsset"),
+  ]),
   _rev: schemas.string(),
   extension: schemas.string(),
   mimeType: schemas.string(),

--- a/packages/groqd/test-utils/pokemon.ts
+++ b/packages/groqd/test-utils/pokemon.ts
@@ -2026,6 +2026,14 @@ const gen1Transformed = gen1.map((mon) => {
     caption: `Artwork of ${mon.name}`,
     description: `${mon.name} has types ${mon.type.join(", ")}.`,
   };
+  const pdf = {
+    _key: `pdfkey-${mon.id}`,
+    _type: "file",
+    asset: {
+      _type: "reference",
+      _ref: `file-${mon.id}-pdf`,
+    },
+  };
 
   return <Pokemon>{
     _id: `pokemon.${mon.id}`,
@@ -2038,6 +2046,7 @@ const gen1Transformed = gen1.map((mon) => {
     })),
     images: [image],
     cover: image,
+    statsSheet: pdf,
     base: mon.base,
   };
 });
@@ -2133,6 +2142,24 @@ const gen1ImageAssets = gen1.map((mon) => ({
   url: "https://cdn.sanity.io/images/nfttuagc/production/ed158069c3b44124a310d7a107998e06bf12e90e-1000x500.jpg",
 }));
 
+const gen1FileAssets = gen1.map((mon) => ({
+  _createdAt: "2022-12-12T19:45:48Z",
+  _id: `file-${mon.id}-pdf`,
+  _rev: "X6HgJNl2Cktkcl6TQwg3gv",
+  _type: "sanity.fileAsset",
+  _updatedAt: "2022-12-12T19:45:48Z",
+  assetId: "ed158069c3b44124a310d7a107998e06bf12e90e",
+  extension: "pdf",
+  metadata: null,
+  mimeType: "application/pdf",
+  originalFilename: `pokemon-${mon.id}.pdf`,
+  path: "files/nfttuagc/production/ed158069c3b44124a310d7a107998e06bf12e90e-1000x500.pdf",
+  sha1hash: "ed158069c3b44124a310d7a107998e06bf12e90e",
+  size: 37594,
+  uploadId: "p9TZMfLbKWO8NPmQnqCES72QVWYlKAWp",
+  url: "https://cdn.sanity.io/files/nfttuagc/production/ed158069c3b44124a310d7a107998e06bf12e90e-1000x500.pdf",
+}));
+
 const types: Type[] = [
   "Grass",
   "Poison",
@@ -2161,5 +2188,6 @@ const types: Type[] = [
 export const pokemonDataset = [
   ...gen1Transformed,
   ...gen1ImageAssets,
+  ...gen1FileAssets,
   ...types,
 ];


### PR DESCRIPTION
If you add a `pdf` file to sanity, for example a brochure that could be downloaded on a click of a link, `groqd` currently throws a zod error of: `'result[0].brochure.asset._type': Invalid literal value, expected "sanity.imageAsset"`.
An example query would be: 
```js
brochure: sanityImage('brochure', {
  withAsset: ['base'],
}),
```
We should be able to add a `pdf` and use the sanity image schema to type the response.

I added a Zod Union of `sanity.fileAsset` & `sanity.imageAsset` which should now allow the type of the file to pass. 
There is potentially a little more work to do here as the file type response is not identical to the Image type response, might need some guidance on how you would want to proceed here.

Open to any feedback and happy to make any requested changes.