### PR TITLE
Add builder `.select$` methods

### DIFF
--- a/.changeset/khaki-buttons-care.md
+++ b/.changeset/khaki-buttons-care.md
@@ -1,0 +1,5 @@
+---
+"groqd": minor
+---
+
+Add .select$ methods to Entity/ArrayQuery classes to mimic grab$

--- a/packages/groqd/src/builder.ts
+++ b/packages/groqd/src/builder.ts
@@ -46,6 +46,21 @@ export class EntityQuery<T extends z.ZodTypeAny> extends BaseQuery<T> {
     });
   }
 
+  select$<Conditions extends ConditionRecord>(
+    s: Conditions
+  ): EntityQuery<Spread<SelectSchemaType<Conditions>>>;
+  select$<S extends ZodUnionAny>(s: BaseQuery<S>): EntityQuery<Spread<S>>;
+  select$<Conditions extends ConditionRecord>(
+    s: Conditions
+  ): EntityQuery<Spread<SelectSchemaType<Conditions>>> {
+    const _select = extendsBaseQuery(s) ? s : select(s, true);
+
+    return new EntityQuery<Spread<SelectSchemaType<Conditions>>>({
+      query: this.query + `{...${_select.query}}`,
+      schema: spreadUnionSchema(_select.schema),
+    });
+  }
+
   grab<
     S extends Selection,
     CondSelections extends Record<string, Selection> | undefined
@@ -138,6 +153,21 @@ export class ArrayQuery<T extends z.ZodTypeAny> extends BaseQuery<
     s: Conditions
   ): ArrayQuery<Spread<SelectSchemaType<Conditions>>> {
     const _select = extendsBaseQuery(s) ? s : select(s);
+
+    return new ArrayQuery<Spread<SelectSchemaType<Conditions>>>({
+      query: this.query + `{...${_select.query}}`,
+      schema: z.array(spreadUnionSchema(_select.schema)),
+    });
+  }
+
+  select$<Conditions extends ConditionRecord>(
+    s: Conditions
+  ): ArrayQuery<Spread<SelectSchemaType<Conditions>>>;
+  select$<S extends ZodUnionAny>(s: BaseQuery<S>): ArrayQuery<Spread<S>>;
+  select$<Conditions extends ConditionRecord>(
+    s: Conditions
+  ): ArrayQuery<Spread<SelectSchemaType<Conditions>>> {
+    const _select = extendsBaseQuery(s) ? s : select(s, true);
 
     return new ArrayQuery<Spread<SelectSchemaType<Conditions>>>({
       query: this.query + `{...${_select.query}}`,

--- a/packages/groqd/src/select.test.ts
+++ b/packages/groqd/src/select.test.ts
@@ -208,6 +208,70 @@ describe("EntityQuery.select()", () => {
   });
 });
 
+describe("EntityQuery.select$()", () => {
+  it("can coerce null values to undefined", async () => {
+    const { data } = await runPokemonQuery(
+      q("*")
+        .filterByType("pokemon")
+        .slice(0)
+        .select$({
+          "name == 'Bulbasaur'": {
+            name: q.literal("Bulbasaur"),
+            foo: q.string().optional(),
+          },
+        })
+    );
+
+    invariant(data);
+    expectTypeOf(data)
+      .exclude<Record<string, never>>()
+      .toEqualTypeOf<{ name: "Bulbasaur"; foo?: string }>();
+    expect(data.name).toBe("Bulbasaur");
+    expect(data.foo).toBe(undefined);
+  });
+
+  it("can coerce null values to undefined with default value", async () => {
+    const { data } = await runPokemonQuery(
+      q("*")
+        .filterByType("pokemon")
+        .slice(0)
+        .select$({
+          "name == 'Bulbasaur'": {
+            name: q.literal("Bulbasaur"),
+            foo: q.string().optional().default("bar"),
+          },
+        })
+    );
+
+    invariant(data);
+    expectTypeOf(data)
+      .exclude<Record<string, never>>()
+      .toEqualTypeOf<{ name: "Bulbasaur"; foo: string }>();
+  });
+
+  it("can coerce null values in default selection to undefined", async () => {
+    const { data } = await runPokemonQuery(
+      q("*")
+        .filterByType("pokemon")
+        .slice(0)
+        .select$({
+          "name == 'Charmander'": {
+            name: q.literal("Charmander"),
+          },
+          default: {
+            foo: q.string().optional(),
+          },
+        })
+    );
+
+    invariant(data);
+    expectTypeOf(data).toEqualTypeOf<
+      { name: "Charmander" } | { foo?: string }
+    >();
+    if ("foo" in data) expect(data.foo).toBe(undefined);
+  });
+});
+
 describe("ArrayQuery.select()", () => {
   it("handles standalone select input", () => {
     const standaloneSelect = q.select({

--- a/packages/groqd/src/select.ts
+++ b/packages/groqd/src/select.ts
@@ -6,9 +6,11 @@ import {
 } from "./selectionUtils";
 import { extendsBaseQuery, isQuerySchemaTuple } from "./typeGuards";
 import type { FromSelection, Selection } from "./types";
+import { nullToUndefined } from "./nullToUndefined";
 
 export const select = <Conditions extends ConditionRecord>(
-  conditionalSelections: Conditions
+  conditionalSelections: Conditions,
+  shouldCoerceNullValues = false
 ) => {
   const getProjection = (
     v: Selection | BaseQuery<any> | [string, z.ZodType]
@@ -50,9 +52,11 @@ export const select = <Conditions extends ConditionRecord>(
         return v[1] as ConditionSchema<Conditions[keyof Conditions]>;
       }
 
-      return getSchemaFromSelection(v as Selection) as ConditionSchema<
-        Conditions[keyof Conditions]
-      >;
+      return getSchemaFromSelection(
+        shouldCoerceNullValues
+          ? nullToUndefined(v as Selection)
+          : (v as Selection)
+      ) as ConditionSchema<Conditions[keyof Conditions]>;
     };
 
     const unionEls = (


### PR DESCRIPTION
Adds the `nullToUndefined` behavior of `.grab$` methods to the `.select` query methods.