### PR TITLE
Arcade: pass params thru

### DIFF
--- a/website/src/arcade/ArcadeEditor.tsx
+++ b/website/src/arcade/ArcadeEditor.tsx
@@ -177,6 +177,7 @@ const runCode = async ({
  */
 const runQuery = async ({
   query,
+  params,
   dispatch,
 }: {
   query: q.BaseQuery<any>;
@@ -194,9 +195,9 @@ const runQuery = async ({
       throw new Error("Error parsing dataset JSON");
     }
 
-    // TODO: Handle params...
     const runner = q.makeSafeQueryRunner(async (query: string) => {
-      const tree = parse(query);
+      console.log("params", params);
+      const tree = parse(query, { params });
       const _ = await evaluate(tree, { dataset: json });
       const rawResponse = await _.get();
       dispatch({ type: "RAW_RESPONSE_RECEIVED", payload: { rawResponse } });

--- a/website/src/arcade/ArcadeEditor.tsx
+++ b/website/src/arcade/ArcadeEditor.tsx
@@ -196,7 +196,6 @@ const runQuery = async ({
     }
 
     const runner = q.makeSafeQueryRunner(async (query: string) => {
-      console.log("params", params);
       const tree = parse(query, { params });
       const _ = await evaluate(tree, { dataset: json });
       const rawResponse = await _.get();


### PR DESCRIPTION
In the arcade, the `runQuery` playground fn as a second arg for params, which just _isn't_ being handled right now (whoops). This PR passes those params through to the GROQ parsing process to mimic how variables/params work in GROQ. [See here](https://groqd-83hn0lblv-formidable-labs.vercel.app/arcade?data=pokemon&code=JYWwDg9gTgLgBAbzlArgOwIooKZQJ5wC%2BcAZlBCHAERgA2AhngObnoAmVA3AFCiSyI4ARyKlylKiwhCOPbqkw58ACm5xhyqgCoqASjVwAdCWC0YuAEJ4AKnjDZNkANbYQENHoPHT5qJrT0INhwALwhcAAkAUGe6oYAzrTAAMYOAAwANHAAHPpxLPQARsoIBurR2ABcwgkwUMBoTMq6GWVw9DAw9MlO1QDaVIX08diGAIKd3U5UWUKGaCgghbjNALqt6oQtBqXq5YFV1ADCABb0UCD0aGy4VAaE3LqcQA) for example.