### PR TITLE
`.order` input type

### DIFF
--- a/.changeset/early-spies-teach.md
+++ b/.changeset/early-spies-teach.md
@@ -1,0 +1,5 @@
+---
+"groqd": patch
+---
+
+Addresses #213, allows the .order method to take an array of strings – since order argument can be more complex than just `FIELD desc`

--- a/packages/groqd/src/builder.ts
+++ b/packages/groqd/src/builder.ts
@@ -201,7 +201,7 @@ export class ArrayQuery<T extends z.ZodTypeAny> extends BaseQuery<
     });
   }
 
-  order(...orderings: `${string} ${"asc" | "desc"}`[]): ArrayQuery<T> {
+  order(...orderings: string[]): ArrayQuery<T> {
     return new ArrayQuery<T>({
       ...this.value(),
       query: this.query + `|order(${orderings.join(", ")})`,


### PR DESCRIPTION
Addresses #213, loosening up the type on the `.order` method a bit – since you can order by more complex expressions than just `FIELD desc`.