### PR TITLE
fix(sanityImage): `_key` as undefined instead of nullable

### DIFF
--- a/packages/groqd/src/sanityImage.ts
+++ b/packages/groqd/src/sanityImage.ts
@@ -30,7 +30,7 @@ const hotspotFields = {
 };
 
 const refBase = {
-  _key: schemas.string().nullable(),
+  _key: schemas.string().optional(),
   _type: schemas.string(),
 } as const;
 


### PR DESCRIPTION
On this pull request, I'm changing the `sanityImage` types to use `_key` as `undefined` instead of `null`.

I think with this change, the error I have using the `PortableText` (React) will be fixed.
- Issue: **https://github.com/FormidableLabs/groqd/issues/221**

### Error screenshot:
![image](https://github.com/FormidableLabs/groqd/assets/18479474/df121b15-0f82-4b49-aa7c-7a0e975d8140)
