### PR TITLE
groq-builder: use `q.infer()` syntax

### DIFF
--- a/packages/groq-builder/README.md
+++ b/packages/groq-builder/README.md
@@ -35,8 +35,8 @@ const productsQuery = (
    .order('price desc')
    .slice(0, 10)
    .project(q => ({
-     name: true,
-     price: true,
+     name: q.infer(),
+     price: q.infer(),
      slug: q.field("slug.current"),
      imageUrls: q.field("images[]").deref().field("url")
    }))
@@ -84,8 +84,8 @@ The `validate` function accepts a simple function:
 
 ```ts
 const products = q.star.filterByType('products').project(q => ({
-  name: true,
-  price: true,
+  name: q.infer(),
+  price: q.infer(),
   priceFormatted: q.field("price").validate(price => formatCurrency(price)),
 }));
 ```

--- a/packages/groq-builder/docs/CONDITIONALS.md
+++ b/packages/groq-builder/docs/CONDITIONALS.md
@@ -85,7 +85,7 @@ Notice that this type is stronger than the example with `q.conditional$`, becaus
 Adds support for the `select$` method:
 ```ts
 const qMovies = q.star.filterByType("movie").project({
-  name: true,
+  name: q.infer(),
   popularity: q.select$({
     "popularity > 20": q.value("high"),
     "popularity > 10": q.value("medium"),

--- a/packages/groq-builder/docs/MIGRATION.md
+++ b/packages/groq-builder/docs/MIGRATION.md
@@ -113,13 +113,13 @@ With `groq-builder`, by [adding a strongly-typed Sanity schema](./README.md#sche
 - Safer to write (all commands are type-checked, all fields are verified)
 - Faster to execute (because runtime validation can be skipped)
 
-In a projection, we can skip runtime validation by simply using `true` instead of a validation method (like `q.string()`).  For example:
+In a projection, we can skip runtime validation by using `q.infer()` instead of a validation method like `q.string()`.  For example:
 ```ts
 const productsQuery = q.star
   .filterByType("product")
   .project({
-    name: true, // 👈 'true' will bypass runtime validation
-    price: true, // 👈 and we still get strong result types from our schema
+    name: q.infer(), // 👈 this will bypass runtime validation
+    price: q.infer(), // 👈 and we still get strong result types from our schema
     slug: "slug.current", // 👈 a naked projection string works too!
   });
 ```

--- a/packages/groq-builder/src/commands/conditional$.test.ts
+++ b/packages/groq-builder/src/commands/conditional$.test.ts
@@ -21,8 +21,8 @@ describe("conditional$", () => {
       },
       "price < msrp": {
         onSale: q.value(true),
-        price: true,
-        msrp: true,
+        price: q.infer(),
+        msrp: q.infer(),
       },
     });
 
@@ -43,15 +43,15 @@ describe("conditional$", () => {
   });
 
   const qAll = qBase.project((qA) => ({
-    name: true,
+    name: q.infer(),
     ...qA.conditional$({
       "price == msrp": {
         onSale: q.value(false),
       },
       "price < msrp": {
         onSale: q.value(true),
-        price: true,
-        msrp: true,
+        price: q.infer(),
+        msrp: q.infer(),
       },
     }),
   }));
@@ -87,22 +87,22 @@ describe("conditional$", () => {
   describe("multiple conditionals", () => {
     describe("without using unique keys", () => {
       const qIncorrect = q.star.filterByType("variant").project((qV) => ({
-        name: true,
+        name: q.infer(),
         ...qV.conditional$({
           "price == msrp": {
             onSale: q.value(false),
           },
           "price < msrp": {
             onSale: q.value(true),
-            price: true,
-            msrp: true,
+            price: q.infer(),
+            msrp: q.infer(),
           },
         }),
         // Here we're trying to spread another conditional,
         // however, it will override the first one
         // since we didn't specify a unique key:
         ...qV.conditional$({
-          "second == condition": { price: true },
+          "second == condition": { price: q.infer() },
         }),
       }));
 
@@ -127,15 +127,15 @@ describe("conditional$", () => {
       const qMultipleConditions = q.star
         .filterByType("variant")
         .project((qV) => ({
-          name: true,
+          name: q.infer(),
           ...qV.conditional$({
             "price == msrp": {
               onSale: q.value(false),
             },
             "price < msrp": {
               onSale: q.value(true),
-              price: true,
-              msrp: true,
+              price: q.infer(),
+              msrp: q.infer(),
             },
           }),
           ...qV.conditional$(

--- a/packages/groq-builder/src/commands/conditionalByType.test.ts
+++ b/packages/groq-builder/src/commands/conditionalByType.test.ts
@@ -23,11 +23,11 @@ const data = mock.generateSeedData({
 
 describe("conditionalByType", () => {
   const conditionalByType = q.star.conditionalByType({
-    variant: { _type: true, name: true, price: true },
-    product: { _type: true, name: true, slug: "slug.current" },
+    variant: { _type: q.infer(), name: q.infer(), price: q.infer() },
+    product: { _type: q.infer(), name: q.infer(), slug: "slug.current" },
     category: (qC) => ({
-      _type: true,
-      name: true,
+      _type: q.infer(),
+      name: q.infer(),
       slug: qC.field("slug.current"),
     }),
   });
@@ -53,13 +53,13 @@ describe("conditionalByType", () => {
   describe("multiple conditionals can be spread", () => {
     const qMultiple = q.star.project((q) => ({
       ...q.conditionalByType({
-        variant: { price: true },
+        variant: { price: q.infer() },
         product: { slug: "slug.current" },
       }),
       ...q.conditionalByType(
         {
-          category: { description: true },
-          style: { name: true },
+          category: { description: q.infer() },
+          style: { name: q.infer() },
         },
         { key: "unique-key" }
       ),
@@ -108,8 +108,8 @@ describe("conditionalByType", () => {
     const conditionsExhaustive = q.star
       .filterByType("product", "variant")
       .conditionalByType({
-        product: { _type: true, name: true },
-        variant: { _type: true, price: true },
+        product: { _type: q.infer(), name: q.infer() },
+        variant: { _type: q.infer(), price: q.infer() },
       });
 
     type ActualItem = ExtractConditionalProjectionTypes<
@@ -136,10 +136,10 @@ describe("conditionalByType", () => {
   });
 
   const qAll = q.star.project((qA) => ({
-    _type: true,
+    _type: q.infer(),
     ...qA.conditionalByType({
-      product: { _type: true, name: true, slug: "slug.current" },
-      variant: { name: true, price: true },
+      product: { _type: q.infer(), name: q.infer(), slug: "slug.current" },
+      variant: { name: q.infer(), price: q.infer() },
     }),
   }));
 

--- a/packages/groq-builder/src/commands/conditionalByType.ts
+++ b/packages/groq-builder/src/commands/conditionalByType.ts
@@ -83,7 +83,7 @@ GroqBuilder.implement({
     const key: TKey = config?.key || ("[ByType]" as TKey);
     const conditionalKey: ConditionalKey<TKey> = `[Conditional] ${key}`;
     return {
-      _type: true, // Ensure we request the `_type` parameter
+      _type: this.infer(), // Ensure we request the `_type` parameter
       [conditionalKey]: conditionalQuery,
     } as any;
   },

--- a/packages/groq-builder/src/commands/functions/infer.ts
+++ b/packages/groq-builder/src/commands/functions/infer.ts
@@ -1,0 +1,31 @@
+import { GroqBuilder } from "../../groq-builder";
+
+/**
+ * Marks a field where we want to infer the type,
+ * and also where we don't want to perform client-side validation
+ * @internal
+ */
+export const inferSymbol = Symbol("inferred");
+export type inferSymbol = typeof inferSymbol;
+
+declare module "../../groq-builder" {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  export interface GroqBuilder<TResult, TRootConfig> {
+    /**
+     * Infers the result type from the schema.
+     *
+     * Performs no client-side validation,
+     * allowing the results to pass through.
+     *
+     * Be sure to only use this when you
+     * trust that your data matches your schema.
+     */
+    infer(): typeof inferSymbol;
+  }
+}
+
+GroqBuilder.implement({
+  infer(): typeof inferSymbol {
+    return inferSymbol;
+  },
+});

--- a/packages/groq-builder/src/commands/functions/nullToUndefined.test.ts
+++ b/packages/groq-builder/src/commands/functions/nullToUndefined.test.ts
@@ -28,15 +28,7 @@ describe("nullToUndefined", () => {
     await expect(() => executeBuilder(qInvalid, data.datalake)).rejects
       .toThrowErrorMatchingInlineSnapshot(`
       "1 Parsing Error:
-      result.description: [
-        {
-          \\"code\\": \\"invalid_type\\",
-          \\"expected\\": \\"string\\",
-          \\"received\\": \\"null\\",
-          \\"path\\": [],
-          \\"message\\": \\"Expected string, received null\\"
-        }
-      ]"
+      result.description: Expected string, received null"
     `);
   });
 

--- a/packages/groq-builder/src/commands/grab-deprecated.test.ts
+++ b/packages/groq-builder/src/commands/grab-deprecated.test.ts
@@ -18,7 +18,7 @@ describe("grab (backwards compatibility)", () => {
 
   it("should be type-safe", () => {
     const qGrab = qVariants.grab((q) => ({
-      name: true,
+      name: q.infer(),
       slug: "slug.current",
       msrp: ["msrp", zod.number()],
       styles: q.grabOne("style[]").deref().grabOne("name"),

--- a/packages/groq-builder/src/commands/project.test.ts
+++ b/packages/groq-builder/src/commands/project.test.ts
@@ -472,7 +472,7 @@ describe("project (object projections)", () => {
       await expect(() => executeBuilder(qNested, dataWithInvalidData)).rejects
         .toThrowErrorMatchingInlineSnapshot(`
         "1 Parsing Error:
-        result[0].images[0].description: Expected string, received 1234"
+        result[0].images[0].description: Expected string, received number"
       `);
     });
   });
@@ -607,7 +607,7 @@ describe("project (object projections)", () => {
       await expect(() => executeBuilder(qParser, invalidData)).rejects
         .toThrowErrorMatchingInlineSnapshot(`
         "1 Parsing Error:
-        result[5].price: Expected number, received \\"INVALID\\""
+        result[5].price: Expected number, received string"
       `);
     });
   });

--- a/packages/groq-builder/src/commands/project.test.ts
+++ b/packages/groq-builder/src/commands/project.test.ts
@@ -7,7 +7,7 @@ import { createGroqBuilder } from "../index";
 import { mock } from "../tests/mocks/nextjs-sanity-fe-mocks";
 import { executeBuilder } from "../tests/mocks/executeQuery";
 import { currencyFormat } from "../tests/utils";
-import { zod } from "../validation/lite";
+import { zod } from "../validation/zod";
 
 const q = createGroqBuilder<SchemaConfig>().include(zod);
 const qVariants = q.star.filterByType("variant");
@@ -68,13 +68,13 @@ describe("project (object projections)", () => {
   describe("a single plain property", () => {
     it("cannot use 'true' to project unknown properties", () => {
       const qInvalid = qVariants.project({
-        INVALID: true,
+        INVALID: q.infer(),
       });
 
       expectType<InferResultType<typeof qInvalid>>().toStrictEqual<
         Array<{
           INVALID: TypeMismatchError<{
-            error: `⛔️ 'true' can only be used for known properties ⛔️`;
+            error: `⛔️ 'q.infer()' can only be used for known properties ⛔️`;
             expected: keyof SanitySchema.Variant;
             actual: "INVALID";
           }>;
@@ -83,7 +83,7 @@ describe("project (object projections)", () => {
     });
 
     const qName = qVariants.project({
-      name: true,
+      name: q.infer(),
     });
     it("query should be typed correctly", () => {
       expect(qName.query).toMatchInlineSnapshot(
@@ -123,10 +123,10 @@ describe("project (object projections)", () => {
 
   describe("multiple plain properties", () => {
     const qMultipleFields = qVariants.project({
-      id: true,
-      name: true,
-      price: true,
-      msrp: true,
+      id: q.infer(),
+      name: q.infer(),
+      price: q.infer(),
+      msrp: q.infer(),
     });
     it("query should be typed correctly", () => {
       expect(qMultipleFields.query).toMatchInlineSnapshot(
@@ -405,7 +405,7 @@ describe("project (object projections)", () => {
     const qNested = qVariants.project((variant) => ({
       name: variant.field("name"),
       images: variant.field("images[]").project((image) => ({
-        name: true,
+        name: q.infer(),
         description: image
           .field("description")
           .validate(zod.nullToUndefined(zod.string().optional())),
@@ -478,11 +478,11 @@ describe("project (object projections)", () => {
   });
 
   describe("mixed projections", () => {
-    const qComplex = qVariants.project((q) => ({
-      name: true,
-      slug: q.field("slug").field("current"),
-      price: true,
-      IMAGES: q.field("images[]").field("name"),
+    const qComplex = qVariants.project((qV) => ({
+      name: q.infer(),
+      slug: qV.field("slug").field("current"),
+      price: q.infer(),
+      IMAGES: qV.field("images[]").field("name"),
     }));
 
     it("query should be correct", () => {
@@ -542,10 +542,10 @@ describe("project (object projections)", () => {
   });
 
   describe("validation", () => {
-    const qParser = qVariants.project((q) => ({
-      name: true,
-      msrp: q.field("msrp").validate((msrp) => currencyFormat(msrp)),
-      price: q.field("price").validate(zod.number()),
+    const qParser = qVariants.project((qV) => ({
+      name: q.infer(),
+      msrp: qV.field("msrp").validate((msrp) => currencyFormat(msrp)),
+      price: qV.field("price").validate(zod.number()),
     }));
 
     it("the types should match", () => {
@@ -613,9 +613,9 @@ describe("project (object projections)", () => {
   });
 
   describe("ellipsis ... operator", () => {
-    const qEllipsis = qVariants.project((q) => ({
-      "...": true,
-      OTHER: q.field("name"),
+    const qEllipsis = qVariants.project((qV) => ({
+      "...": q.infer(),
+      OTHER: qV.field("name"),
     }));
     it("query should be correct", () => {
       expect(qEllipsis.query).toMatchInlineSnapshot(

--- a/packages/groq-builder/src/commands/project.ts
+++ b/packages/groq-builder/src/commands/project.ts
@@ -13,6 +13,7 @@ import {
   simpleArrayParser,
   simpleObjectParser,
 } from "../validation/simple-validation";
+import { inferSymbol } from "./functions/infer";
 
 declare module "../groq-builder" {
   export interface GroqBuilder<TResult, TRootConfig> {
@@ -81,12 +82,17 @@ function normalizeProjectionField(
       ? key
       : `"${key}": ${value.query}`;
     return { key, query, parser: value.parser };
+  } else if (value === inferSymbol) {
+    return { key, query: key, parser: null };
   } else if (typeof value === "string") {
     const query = key === value ? key : `"${key}": ${value}`;
     return { key, query, parser: null };
-  } else if (typeof value === "boolean") {
-    if (value === false) return null; // 'false' will be excluded from the results
-    return { key, query: key, parser: null };
+  } else if (isParser(value)) {
+    return {
+      key,
+      query: key,
+      parser: normalizeValidationFunction(value),
+    };
   } else if (Array.isArray(value)) {
     const [projectionKey, parser] = value as [string, Parser];
     const query = key === projectionKey ? key : `"${key}": ${projectionKey}`;
@@ -95,12 +101,6 @@ function normalizeProjectionField(
       key,
       query,
       parser: normalizeValidationFunction(parser),
-    };
-  } else if (isParser(value)) {
-    return {
-      key,
-      query: key,
-      parser: normalizeValidationFunction(value),
     };
   } else {
     throw new Error(

--- a/packages/groq-builder/src/commands/projection-types.ts
+++ b/packages/groq-builder/src/commands/projection-types.ts
@@ -21,6 +21,7 @@ import {
   ExtractConditionalProjectionTypes,
   OmitConditionalProjections,
 } from "./conditional-types";
+import { inferSymbol } from "./functions/infer";
 
 export type ProjectionKey<TResultItem> = IsAny<TResultItem> extends true
   ? string
@@ -43,7 +44,7 @@ export type ProjectionMap<TResultItem> = {
   >;
 } & {
   // Obviously this allows the ellipsis operator:
-  "..."?: true;
+  "..."?: inferSymbol;
 };
 
 export type ProjectionMapOrCallback<
@@ -54,8 +55,8 @@ export type ProjectionMapOrCallback<
   | ((q: GroqBuilder<TResultItem, TRootConfig>) => ProjectionMap<TResultItem>);
 
 export type ProjectionFieldConfig<TResultItem, TFieldType> =
-  // Use 'true' to include a field as-is
-  | true
+  // Use 'q.infer()' to include a field as-is, no transformations/parsers
+  | inferSymbol
   // Use a string for naked projections, like 'slug.current'
   | ProjectionKey<TResultItem>
   // Use a parser to include a field, passing it through the parser at run-time
@@ -66,7 +67,7 @@ export type ProjectionFieldConfig<TResultItem, TFieldType> =
   | IGroqBuilder;
 
 export type ExtractProjectionResult<TResultItem, TProjectionMap> =
-  (TProjectionMap extends { "...": true } ? TResultItem : Empty) &
+  (TProjectionMap extends { "...": inferSymbol } ? TResultItem : Empty) &
     ExtractProjectionResultImpl<
       TResultItem,
       Omit<
@@ -82,12 +83,12 @@ type ExtractProjectionResultImpl<TResultItem, TProjectionMap> = {
     infer TValue
   > // Extract type from GroqBuilder:
     ? TValue
-    : /* Extract type from 'true': */
-    TProjectionMap[P] extends boolean
+    : /* Extract type from 'inferSymbol': */
+    TProjectionMap[P] extends inferSymbol
     ? P extends keyof TResultItem
       ? TResultItem[P]
       : TypeMismatchError<{
-          error: `⛔️ 'true' can only be used for known properties ⛔️`;
+          error: `⛔️ 'q.infer()' can only be used for known properties ⛔️`;
           expected: keyof TResultItem;
           actual: P;
         }>

--- a/packages/groq-builder/src/commands/select$.test.ts
+++ b/packages/groq-builder/src/commands/select$.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { createGroqBuilder, InferResultType, validation } from "../index";
+import { createGroqBuilder, InferResultType, zod } from "../index";
 import { SchemaConfig } from "../tests/schemas/nextjs-sanity-fe";
 import { expectType } from "../tests/expectType";
 import { mock } from "../tests/mocks/nextjs-sanity-fe-mocks";
@@ -129,13 +129,13 @@ describe("select$", () => {
     const qSelect = qBase.project((q) => ({
       selected: q.select$({
         '_type == "product"': q.asType<"product">().project({
-          _type: validation.literal("product"),
-          name: validation.string(),
+          _type: zod.literal("product"),
+          name: zod.string(),
         }),
         '_type == "variant"': q.asType<"variant">().project({
-          _type: validation.literal("variant"),
-          name: validation.string(),
-          price: validation.number(),
+          _type: zod.literal("variant"),
+          name: zod.string(),
+          price: zod.number(),
         }),
       }),
     }));

--- a/packages/groq-builder/src/commands/selectByType.test.ts
+++ b/packages/groq-builder/src/commands/selectByType.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { expectType } from "../tests/expectType";
-import { createGroqBuilder, InferResultType, validation } from "../index";
+import { createGroqBuilder, InferResultType, zod } from "../index";
 import { SchemaConfig } from "../tests/schemas/nextjs-sanity-fe";
 import { executeBuilder } from "../tests/mocks/executeQuery";
 import { mock } from "../tests/mocks/nextjs-sanity-fe-mocks";
@@ -49,14 +49,14 @@ describe("selectByType", () => {
       selected: q.selectByType({
         product: (q) =>
           q.project({
-            _type: true,
-            name: true,
+            _type: q.infer(),
+            name: q.infer(),
           }),
         variant: (q) =>
           q.project({
-            _type: true,
-            name: true,
-            price: true,
+            _type: q.infer(),
+            name: q.infer(),
+            price: q.infer(),
           }),
       }),
     }));
@@ -210,14 +210,14 @@ describe("selectByType", () => {
       selected: q.selectByType({
         product: (q) =>
           q.project({
-            _type: validation.literal("product"),
-            name: validation.string(),
+            _type: zod.literal("product"),
+            name: zod.string(),
           }),
         variant: (q) =>
           q.project({
-            _type: validation.literal("variant"),
-            name: validation.string(),
-            price: validation.number(),
+            _type: zod.literal("variant"),
+            name: zod.string(),
+            price: zod.number(),
           }),
       }),
     }));

--- a/packages/groq-builder/src/groq-builder.test.ts
+++ b/packages/groq-builder/src/groq-builder.test.ts
@@ -21,24 +21,24 @@ describe("GroqBuilder", () => {
       .filterByType("product")
       .filter("slug.current == $slug")
       .grab((q) => ({
-        _id: true,
-        name: true,
+        _id: q.infer(),
+        name: q.infer(),
         categories: q.field("categories[]").deref().grab({
-          name: true,
+          name: q.infer(),
         }),
         slug: q.field("slug").field("current"),
         variants: q
           .field("variants[]")
           .deref()
           .grab((q) => ({
-            _id: true,
-            name: true,
-            msrp: true,
-            price: true,
+            _id: q.infer(),
+            name: q.infer(),
+            msrp: q.infer(),
+            price: q.infer(),
             slug: q.field("slug").field("current"),
             style: q.field("style[]").deref().grab({
-              _id: true,
-              name: true,
+              _id: q.infer(),
+              name: q.infer(),
             }),
           })),
       }));


### PR DESCRIPTION
# What

Changes syntax for inferred types.  
Previously, you'd bypass validation and simply infer a type by using `true` in a projection.

Instead, this requires you to use `q.infer()`, making it more obvious what it does.

