### PR TITLE
groq-builder: fixed build issues

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -35,7 +35,9 @@ jobs:
 
       - name: Build library
         run: pnpm run build:lib
+
       - name: Type Check
         run: pnpm run typecheck
+
       - name: Lint
         run: pnpm run lint

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "typecheck:shared": "tsc --project tsconfig.shared.json --noEmit",
     "typecheck": "pnpm run typecheck:shared && pnpm run -r typecheck",
     "check:ci": "pnpm run typecheck && pnpm run lint && pnpm run test",
-    "build:lib": "pnpm run --filter groqd build",
+    "build:lib": "pnpm run --filter groqd --filter groq-builder build",
     "build:packages": "pnpm run --filter groqd --filter groqd-playground build",
     "build": "pnpm run -r build",
     "changeset": "changeset",

--- a/packages/groq-builder/src/commands/select$.ts
+++ b/packages/groq-builder/src/commands/select$.ts
@@ -52,7 +52,8 @@ GroqBuilder.implement({
         "When using 'select', either all conditions must have validation, or none of them. " +
           `Missing validation: "${missing.join('", "')}"`
       );
-      Error.captureStackTrace(err, GroqBuilder.prototype.select$);
+      // This only works on V8 engines:
+      (Error as any).captureStackTrace?.(err, GroqBuilder.prototype.select$);
       throw err;
     }
 

--- a/packages/groq-builder/tsconfig.json
+++ b/packages/groq-builder/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": "../../tsconfig.json"
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "target": "ES2019",
+  }
 }


### PR DESCRIPTION
# What

Version 0.3.0 failed to publish, due to needing a higher target build related to `Object.entries` and `Object.fromEntries`.

This PR changes the build target, and adds a build step in CI to verify the build will succeed.
