### PR TITLE
groq-builder: fixed a type issue with `project`

### DIFF
--- a/.changeset/time-for-rc.md
+++ b/.changeset/time-for-rc.md
@@ -1,0 +1,5 @@
+---
+"groq-builder": minor
+---
+
+Releasing as a Release Candidate

--- a/.changeset/witty-timers-care.md
+++ b/.changeset/witty-timers-care.md
@@ -1,0 +1,5 @@
+---
+"groq-builder": patch
+---
+
+Fixed a type issue with `project`, where it would complain `argument [] is not assignable to 'never'`

--- a/packages/groq-builder/README.md
+++ b/packages/groq-builder/README.md
@@ -1,8 +1,3 @@
-# WARNING: this package is in "beta" state; feel free to use at your own risk
-
-> If you're looking for a feature-complete, strongly-typed Groq utility, please use [GroqD](https://formidable.com/open-source/groqd/).
-> This package aims to be a successor to GroqD, but is not yet feature-complete.  Please use at your own risk.
-
 # `groq-builder`
 
 A **schema-aware**, strongly-typed GROQ query builder.  

--- a/packages/groq-builder/package.json
+++ b/packages/groq-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "groq-builder",
-  "version": "0.5.0",
+  "version": "0.8.0",
   "license": "MIT",
   "author": {
     "name": "Formidable",

--- a/packages/groq-builder/src/commands/project.ts
+++ b/packages/groq-builder/src/commands/project.ts
@@ -1,4 +1,8 @@
-import { ExtractTypeMismatchErrors, notNull, Simplify } from "../types/utils";
+import {
+  notNull,
+  RequireAFakeParameterIfThereAreTypeMismatchErrors,
+  Simplify,
+} from "../types/utils";
 import { GroqBuilder } from "../groq-builder";
 import { Parser, ParserFunction } from "../types/public-types";
 import { isParser, normalizeValidationFunction } from "./validate-utils";
@@ -41,24 +45,6 @@ declare module "../groq-builder" {
     >;
   }
 }
-
-/**
- * When we map projection results, we return TypeMismatchError's
- * for any fields that have an invalid mapping configuration.
- * However, this does not cause TypeScript to throw any errors.
- *
- * In order to get TypeScript to complain about these invalid mappings,
- * we will "require" an extra parameter, which will reveal the error messages.
- */
-type RequireAFakeParameterIfThereAreTypeMismatchErrors<
-  TProjectionResult,
-  _Errors extends never | string = ExtractTypeMismatchErrors<TProjectionResult>
-> = _Errors extends never
-  ? [] // No errors, yay! Do not require any extra parameters.
-  : // We've got errors; let's require an extra parameter, with the error message:
-    | [_Errors]
-      // And this extra error message causes TypeScript to always log the entire list of errors:
-      | ["⛔️ Error: this projection has type mismatches: ⛔️"];
 
 GroqBuilder.implement({
   project(

--- a/packages/groq-builder/src/tests/mocks/nextjs-sanity-fe-mocks.ts
+++ b/packages/groq-builder/src/tests/mocks/nextjs-sanity-fe-mocks.ts
@@ -1,4 +1,5 @@
 import { referenced, SanitySchema } from "../schemas/nextjs-sanity-fe";
+import { decorator } from "../schemas/nextjs-sanity-fe.generated";
 
 export class MockFactory {
   // Common helpers:
@@ -116,7 +117,11 @@ export class MockFactory {
     return {
       _type: "block",
       _key: "",
-      children: [{ _type: "span", _key: "", text: "", marks: [] }],
+      children: [
+        { _type: "span", _key: "", text: "", marks: [], [decorator]: null },
+      ],
+      markDefs: [],
+      style: undefined,
       ...data,
     };
   }

--- a/packages/groq-builder/src/tests/schemas/nextjs-sanity-fe.generated.ts
+++ b/packages/groq-builder/src/tests/schemas/nextjs-sanity-fe.generated.ts
@@ -46,7 +46,12 @@ export type SchemaValues = {
     metadata: {
       [x: string]: unknown;
       _type: "sanity.imageMetadata";
-      dimensions: { _type: "sanity.imageDimensions"; height: number; width: number; aspectRatio: number };
+      dimensions: {
+        _type: "sanity.imageDimensions";
+        height: number;
+        width: number;
+        aspectRatio: number;
+      };
       palette?:
         | {
             _type: "sanity.imagePalette";
@@ -119,13 +124,28 @@ export type SchemaValues = {
       blurHash?: string | undefined;
       hasAlpha: boolean;
       isOpaque: boolean;
-      exif?: { [x: string]: unknown; _type: "sanity.imageExifMetadata" } | undefined;
-      location?: { _type: "geopoint"; lat: number; lng: number; alt?: number | undefined } | undefined;
+      exif?:
+        | { [x: string]: unknown; _type: "sanity.imageExifMetadata" }
+        | undefined;
+      location?:
+        | {
+            _type: "geopoint";
+            lat: number;
+            lng: number;
+            alt?: number | undefined;
+          }
+        | undefined;
     };
   };
   description: {
     _type: "block";
-    children: { text: string; _type: "span"; [decorator]: any; marks: string[]; _key: string }[];
+    children: {
+      text: string;
+      _type: "span";
+      [decorator]: any;
+      marks: string[];
+      _key: string;
+    }[];
     level?: number | undefined;
     listItem?: any;
     markDefs: never[];
@@ -149,7 +169,14 @@ export type SchemaValues = {
     _id: string;
     _rev: string;
     _updatedAt: string;
-    images?: { _ref: string; _type: "reference"; [referenced]: "categoryImage"; _key: string }[] | undefined;
+    images?:
+      | {
+          _ref: string;
+          _type: "reference";
+          [referenced]: "categoryImage";
+          _key: string;
+        }[]
+      | undefined;
     _type: "category";
   };
   categoryImage: {
@@ -159,7 +186,14 @@ export type SchemaValues = {
     _id: string;
     _rev: string;
     _updatedAt: string;
-    images: { _type: "image"; asset: { _ref: string; _type: "reference"; [referenced]: "sanity.imageAsset" } };
+    images: {
+      _type: "image";
+      asset: {
+        _ref: string;
+        _type: "reference";
+        [referenced]: "sanity.imageAsset";
+      };
+    };
     _type: "categoryImage";
   };
   flavour: {
@@ -177,7 +211,13 @@ export type SchemaValues = {
     description?:
       | {
           _type: "block";
-          children: { text: string; _type: "span"; [decorator]: any; marks: string[]; _key: string }[];
+          children: {
+            text: string;
+            _type: "span";
+            [decorator]: any;
+            marks: string[];
+            _key: string;
+          }[];
           level?: number | undefined;
           listItem?: any;
           markDefs: never[];
@@ -193,19 +233,41 @@ export type SchemaValues = {
       | {
           name: string;
           description?: string | undefined;
-          asset: { _ref: string; _type: "reference"; [referenced]: "sanity.imageAsset" };
+          asset: {
+            _ref: string;
+            _type: "reference";
+            [referenced]: "sanity.imageAsset";
+          };
           _type: "productImage";
           _key: string;
         }[]
       | undefined;
-    categories?: { _ref: string; _type: "reference"; [referenced]: "category"; _key: string }[] | undefined;
-    variants?: { _ref: string; _type: "reference"; [referenced]: "variant"; _key: string }[] | undefined;
+    categories?:
+      | {
+          _ref: string;
+          _type: "reference";
+          [referenced]: "category";
+          _key: string;
+        }[]
+      | undefined;
+    variants?:
+      | {
+          _ref: string;
+          _type: "reference";
+          [referenced]: "variant";
+          _key: string;
+        }[]
+      | undefined;
     _type: "product";
   };
   productImage: {
     name: string;
     description?: string | undefined;
-    asset: { _ref: string; _type: "reference"; [referenced]: "sanity.imageAsset" };
+    asset: {
+      _ref: string;
+      _type: "reference";
+      [referenced]: "sanity.imageAsset";
+    };
     _type: "productImage";
   };
   variant: {
@@ -214,7 +276,13 @@ export type SchemaValues = {
     description?:
       | {
           _type: "block";
-          children: { text: string; _type: "span"; [decorator]: any; marks: string[]; _key: string }[];
+          children: {
+            text: string;
+            _type: "span";
+            [decorator]: any;
+            marks: string[];
+            _key: string;
+          }[];
           level?: number | undefined;
           listItem?: any;
           markDefs: never[];
@@ -222,7 +290,14 @@ export type SchemaValues = {
           _key: string;
         }[]
       | undefined;
-    style?: { _ref: string; _type: "reference"; [referenced]: "style"; _key: string }[] | undefined;
+    style?:
+      | {
+          _ref: string;
+          _type: "reference";
+          [referenced]: "style";
+          _key: string;
+        }[]
+      | undefined;
     id?: string | undefined;
     _createdAt: string;
     _id: string;
@@ -232,12 +307,23 @@ export type SchemaValues = {
       | {
           name: string;
           description?: string | undefined;
-          asset: { _ref: string; _type: "reference"; [referenced]: "sanity.imageAsset" };
+          asset: {
+            _ref: string;
+            _type: "reference";
+            [referenced]: "sanity.imageAsset";
+          };
           _type: "productImage";
           _key: string;
         }[]
       | undefined;
-    flavour?: { _ref: string; _type: "reference"; [referenced]: "flavour"; _key: string }[] | undefined;
+    flavour?:
+      | {
+          _ref: string;
+          _type: "reference";
+          [referenced]: "flavour";
+          _key: string;
+        }[]
+      | undefined;
     msrp: number;
     price: number;
     _type: "variant";

--- a/packages/groq-builder/src/tests/schemas/nextjs-sanity-fe.generated.ts
+++ b/packages/groq-builder/src/tests/schemas/nextjs-sanity-fe.generated.ts
@@ -1,0 +1,254 @@
+/* Types generated from './sanity-studio/sanity.config.ts' */
+
+export declare const decorator: unique symbol;
+export declare const referenced: unique symbol;
+export type SchemaValues = {
+  "sanity.fileAsset": {
+    _type: "sanity.fileAsset";
+    metadata: { [x: string]: unknown };
+    url: string;
+    path: string;
+    assetId: string;
+    extension: string;
+    mimeType: string;
+    sha1hash: string;
+    size: number;
+    originalFilename?: string | undefined;
+    label?: string | undefined;
+    title?: string | undefined;
+    description?: string | undefined;
+    creditLine?: string | undefined;
+    source?: { id: string; name: string; url?: string | undefined } | undefined;
+    _id: string;
+    _createdAt: string;
+    _updatedAt: string;
+    _rev: string;
+  };
+  "sanity.imageAsset": {
+    _type: "sanity.imageAsset";
+    url: string;
+    path: string;
+    assetId: string;
+    extension: string;
+    mimeType: string;
+    sha1hash: string;
+    size: number;
+    originalFilename?: string | undefined;
+    label?: string | undefined;
+    title?: string | undefined;
+    description?: string | undefined;
+    creditLine?: string | undefined;
+    source?: { id: string; name: string; url?: string | undefined } | undefined;
+    _id: string;
+    _createdAt: string;
+    _updatedAt: string;
+    _rev: string;
+    metadata: {
+      [x: string]: unknown;
+      _type: "sanity.imageMetadata";
+      dimensions: { _type: "sanity.imageDimensions"; height: number; width: number; aspectRatio: number };
+      palette?:
+        | {
+            _type: "sanity.imagePalette";
+            darkMuted?:
+              | {
+                  _type: "sanity.imagePaletteSwatch";
+                  background: string;
+                  foreground: string;
+                  population: number;
+                  title?: string | undefined;
+                }
+              | undefined;
+            darkVibrant?:
+              | {
+                  _type: "sanity.imagePaletteSwatch";
+                  background: string;
+                  foreground: string;
+                  population: number;
+                  title?: string | undefined;
+                }
+              | undefined;
+            dominant?:
+              | {
+                  _type: "sanity.imagePaletteSwatch";
+                  background: string;
+                  foreground: string;
+                  population: number;
+                  title?: string | undefined;
+                }
+              | undefined;
+            lightMuted?:
+              | {
+                  _type: "sanity.imagePaletteSwatch";
+                  background: string;
+                  foreground: string;
+                  population: number;
+                  title?: string | undefined;
+                }
+              | undefined;
+            lightVibrant?:
+              | {
+                  _type: "sanity.imagePaletteSwatch";
+                  background: string;
+                  foreground: string;
+                  population: number;
+                  title?: string | undefined;
+                }
+              | undefined;
+            muted?:
+              | {
+                  _type: "sanity.imagePaletteSwatch";
+                  background: string;
+                  foreground: string;
+                  population: number;
+                  title?: string | undefined;
+                }
+              | undefined;
+            vibrant?:
+              | {
+                  _type: "sanity.imagePaletteSwatch";
+                  background: string;
+                  foreground: string;
+                  population: number;
+                  title?: string | undefined;
+                }
+              | undefined;
+          }
+        | undefined;
+      lqip?: string | undefined;
+      blurHash?: string | undefined;
+      hasAlpha: boolean;
+      isOpaque: boolean;
+      exif?: { [x: string]: unknown; _type: "sanity.imageExifMetadata" } | undefined;
+      location?: { _type: "geopoint"; lat: number; lng: number; alt?: number | undefined } | undefined;
+    };
+  };
+  description: {
+    _type: "block";
+    children: { text: string; _type: "span"; [decorator]: any; marks: string[]; _key: string }[];
+    level?: number | undefined;
+    listItem?: any;
+    markDefs: never[];
+    style: any;
+    _key: string;
+  }[];
+  style: {
+    name?: string | undefined;
+    slug: { _type: "slug"; current: string };
+    _createdAt: string;
+    _id: string;
+    _rev: string;
+    _updatedAt: string;
+    _type: "style";
+  };
+  category: {
+    name: string;
+    slug: { _type: "slug"; current: string };
+    description?: string | undefined;
+    _createdAt: string;
+    _id: string;
+    _rev: string;
+    _updatedAt: string;
+    images?: { _ref: string; _type: "reference"; [referenced]: "categoryImage"; _key: string }[] | undefined;
+    _type: "category";
+  };
+  categoryImage: {
+    name: string;
+    description?: string | undefined;
+    _createdAt: string;
+    _id: string;
+    _rev: string;
+    _updatedAt: string;
+    images: { _type: "image"; asset: { _ref: string; _type: "reference"; [referenced]: "sanity.imageAsset" } };
+    _type: "categoryImage";
+  };
+  flavour: {
+    name?: string | undefined;
+    slug: { _type: "slug"; current: string };
+    _createdAt: string;
+    _id: string;
+    _rev: string;
+    _updatedAt: string;
+    _type: "flavour";
+  };
+  product: {
+    name: string;
+    slug: { _type: "slug"; current: string };
+    description?:
+      | {
+          _type: "block";
+          children: { text: string; _type: "span"; [decorator]: any; marks: string[]; _key: string }[];
+          level?: number | undefined;
+          listItem?: any;
+          markDefs: never[];
+          style: any;
+          _key: string;
+        }[]
+      | undefined;
+    _createdAt: string;
+    _id: string;
+    _rev: string;
+    _updatedAt: string;
+    images?:
+      | {
+          name: string;
+          description?: string | undefined;
+          asset: { _ref: string; _type: "reference"; [referenced]: "sanity.imageAsset" };
+          _type: "productImage";
+          _key: string;
+        }[]
+      | undefined;
+    categories?: { _ref: string; _type: "reference"; [referenced]: "category"; _key: string }[] | undefined;
+    variants?: { _ref: string; _type: "reference"; [referenced]: "variant"; _key: string }[] | undefined;
+    _type: "product";
+  };
+  productImage: {
+    name: string;
+    description?: string | undefined;
+    asset: { _ref: string; _type: "reference"; [referenced]: "sanity.imageAsset" };
+    _type: "productImage";
+  };
+  variant: {
+    name: string;
+    slug: { _type: "slug"; current: string };
+    description?:
+      | {
+          _type: "block";
+          children: { text: string; _type: "span"; [decorator]: any; marks: string[]; _key: string }[];
+          level?: number | undefined;
+          listItem?: any;
+          markDefs: never[];
+          style: any;
+          _key: string;
+        }[]
+      | undefined;
+    style?: { _ref: string; _type: "reference"; [referenced]: "style"; _key: string }[] | undefined;
+    id?: string | undefined;
+    _createdAt: string;
+    _id: string;
+    _rev: string;
+    _updatedAt: string;
+    images?:
+      | {
+          name: string;
+          description?: string | undefined;
+          asset: { _ref: string; _type: "reference"; [referenced]: "sanity.imageAsset" };
+          _type: "productImage";
+          _key: string;
+        }[]
+      | undefined;
+    flavour?: { _ref: string; _type: "reference"; [referenced]: "flavour"; _key: string }[] | undefined;
+    msrp: number;
+    price: number;
+    _type: "variant";
+  };
+  siteSettings: {
+    title?: string | undefined;
+    description?: string | undefined;
+    _createdAt: string;
+    _id: string;
+    _rev: string;
+    _updatedAt: string;
+    _type: "siteSettings";
+  };
+};

--- a/packages/groq-builder/src/tests/schemas/nextjs-sanity-fe.ts
+++ b/packages/groq-builder/src/tests/schemas/nextjs-sanity-fe.ts
@@ -3,6 +3,8 @@ import { ExtractDocumentTypes } from "../../types/schema-types";
 import { Simplify } from "../../types/utils";
 import { referenced, SchemaValues } from "./nextjs-sanity-fe.generated";
 
+export { referenced };
+
 export type SchemaConfig = {
   documentTypes: ExtractDocumentTypes<SanitySchema.Reconstructed>;
   referenceSymbol: typeof referenced;

--- a/packages/groq-builder/src/tests/schemas/nextjs-sanity-fe.ts
+++ b/packages/groq-builder/src/tests/schemas/nextjs-sanity-fe.ts
@@ -1,6 +1,7 @@
 // Types generated from "./sanity-studio/sanity.config.ts"
 import { ExtractDocumentTypes } from "../../types/schema-types";
 import { Simplify } from "../../types/utils";
+import { referenced, SchemaValues } from "./nextjs-sanity-fe.generated";
 
 export type SchemaConfig = {
   documentTypes: ExtractDocumentTypes<SanitySchema.Reconstructed>;
@@ -11,23 +12,22 @@ export type SchemaConfig = {
 export namespace SanitySchema {
   // We're going to "reconstruct" our types here,
   // so that we get better type aliases when debugging:
-  export type Description = SanitySchemaGenerated["description"];
-  export type Style = PromoteType<SanitySchemaGenerated["style"]>;
-  export type Category = PromoteType<SanitySchemaGenerated["category"]>;
-  export type CategoryImage = PromoteType<
-    SanitySchemaGenerated["categoryImage"]
-  >;
-  export type Flavour = PromoteType<SanitySchemaGenerated["flavour"]>;
-  export type Product = PromoteType<SanitySchemaGenerated["product"]>;
-  export type ProductImage = PromoteType<SanitySchemaGenerated["productImage"]>;
-  export type Variant = PromoteType<SanitySchemaGenerated["variant"]>;
-  export type SiteSettings = PromoteType<SanitySchemaGenerated["siteSettings"]>;
-
-  export type ContentBlock = NonNullable<Variant["description"]>[0];
 
   type PromoteType<T extends { _type: string }> = {
     _type: T["_type"];
   } & Simplify<Omit<T, "_type">>;
+
+  export type Description = SchemaValues["description"];
+  export type Style = PromoteType<SchemaValues["style"]>;
+  export type Category = PromoteType<SchemaValues["category"]>;
+  export type CategoryImage = PromoteType<SchemaValues["categoryImage"]>;
+  export type Flavour = PromoteType<SchemaValues["flavour"]>;
+  export type Product = PromoteType<SchemaValues["product"]>;
+  export type ProductImage = PromoteType<SchemaValues["productImage"]>;
+  export type Variant = PromoteType<SchemaValues["variant"]>;
+  export type SiteSettings = PromoteType<SchemaValues["siteSettings"]>;
+  export type SanityImageAsset = PromoteType<SchemaValues["sanity.imageAsset"]>;
+  export type SanityFileAsset = PromoteType<SchemaValues["sanity.fileAsset"]>;
 
   export type Reconstructed = {
     description: Description;
@@ -39,323 +39,9 @@ export namespace SanitySchema {
     productImage: ProductImage;
     variant: Variant;
     siteSettings: SiteSettings;
+    "sanity.imageAsset": SanityImageAsset;
+    "sanity.fileAsset": SanityFileAsset;
   };
-}
 
-export declare const referenced: unique symbol;
-type SanitySchemaGenerated = {
-  description: {
-    _type: "block";
-    children: {
-      _type: "span";
-      text: string;
-      marks?: string[] | undefined;
-      _key: string;
-    }[];
-    markDefs?: { _type: string; _key: string }[] | undefined;
-    style?: string | undefined;
-    listItem?: string | undefined;
-    level?: number | undefined;
-    _key: string;
-  }[];
-  style: {
-    slug: { _type: "slug"; current: string };
-    name?: string | undefined;
-    _id: string;
-    _createdAt: string;
-    _updatedAt: string;
-    _rev: string;
-    _type: "style";
-  };
-  category: {
-    slug: { _type: "slug"; current: string };
-    name: string;
-    description?: string | undefined;
-    _id: string;
-    _createdAt: string;
-    _updatedAt: string;
-    _rev: string;
-    images?:
-      | {
-          _ref: string;
-          _weak?: boolean | undefined;
-          _strengthenOnPublish?:
-            | {
-                type: string;
-                weak?: boolean | undefined;
-                template?:
-                  | {
-                      id: string;
-                      params: { [x: string]: string | number | boolean };
-                    }
-                  | undefined;
-              }
-            | undefined;
-          _type: "reference";
-          [referenced]: "categoryImage";
-          _key: string;
-        }[]
-      | undefined;
-    _type: "category";
-  };
-  categoryImage: {
-    name: string;
-    description?: string | undefined;
-    _id: string;
-    _createdAt: string;
-    _updatedAt: string;
-    _rev: string;
-    images: {
-      _type: "image";
-      asset: {
-        _type: string;
-        _ref: string;
-        _key?: string | undefined;
-        _weak?: boolean | undefined;
-        _strengthenOnPublish?:
-          | {
-              type: string;
-              weak?: boolean | undefined;
-              template?:
-                | {
-                    id: string;
-                    params: { [x: string]: string | number | boolean };
-                  }
-                | undefined;
-            }
-          | undefined;
-      };
-    };
-    _type: "categoryImage";
-  };
-  flavour: {
-    slug: { _type: "slug"; current: string };
-    name?: string | undefined;
-    _id: string;
-    _createdAt: string;
-    _updatedAt: string;
-    _rev: string;
-    _type: "flavour";
-  };
-  product: {
-    slug: { _type: "slug"; current: string };
-    name: string;
-    description?:
-      | {
-          _type: "block";
-          children: {
-            _type: "span";
-            text: string;
-            marks?: string[] | undefined;
-            _key: string;
-          }[];
-          markDefs?: { _type: string; _key: string }[] | undefined;
-          style?: string | undefined;
-          listItem?: string | undefined;
-          level?: number | undefined;
-          _key: string;
-        }[]
-      | undefined;
-    _id: string;
-    _createdAt: string;
-    _updatedAt: string;
-    _rev: string;
-    images?:
-      | {
-          name: string;
-          description?: string | undefined;
-          asset: {
-            _type: string;
-            _ref: string;
-            _key?: string | undefined;
-            _weak?: boolean | undefined;
-            _strengthenOnPublish?:
-              | {
-                  type: string;
-                  weak?: boolean | undefined;
-                  template?:
-                    | {
-                        id: string;
-                        params: { [x: string]: string | number | boolean };
-                      }
-                    | undefined;
-                }
-              | undefined;
-          };
-          _type: "productImage";
-          _key: string;
-        }[]
-      | undefined;
-    categories?:
-      | {
-          _ref: string;
-          _weak?: boolean | undefined;
-          _strengthenOnPublish?:
-            | {
-                type: string;
-                weak?: boolean | undefined;
-                template?:
-                  | {
-                      id: string;
-                      params: { [x: string]: string | number | boolean };
-                    }
-                  | undefined;
-              }
-            | undefined;
-          _type: "reference";
-          [referenced]: "category";
-          _key: string;
-        }[]
-      | undefined;
-    variants?:
-      | {
-          _ref: string;
-          _weak?: boolean | undefined;
-          _strengthenOnPublish?:
-            | {
-                type: string;
-                weak?: boolean | undefined;
-                template?:
-                  | {
-                      id: string;
-                      params: { [x: string]: string | number | boolean };
-                    }
-                  | undefined;
-              }
-            | undefined;
-          _type: "reference";
-          [referenced]: "variant";
-          _key: string;
-        }[]
-      | undefined;
-    _type: "product";
-  };
-  productImage: {
-    name: string;
-    description?: string | undefined;
-    asset: {
-      _type: string;
-      _ref: string;
-      _key?: string | undefined;
-      _weak?: boolean | undefined;
-      _strengthenOnPublish?:
-        | {
-            type: string;
-            weak?: boolean | undefined;
-            template?:
-              | {
-                  id: string;
-                  params: { [x: string]: string | number | boolean };
-                }
-              | undefined;
-          }
-        | undefined;
-    };
-    _type: "productImage";
-  };
-  variant: {
-    slug: { _type: "slug"; current: string };
-    name: string;
-    description?:
-      | {
-          _type: "block";
-          children: {
-            _type: "span";
-            text: string;
-            marks?: string[] | undefined;
-            _key: string;
-          }[];
-          markDefs?: { _type: string; _key: string }[] | undefined;
-          style?: string | undefined;
-          listItem?: string | undefined;
-          level?: number | undefined;
-          _key: string;
-        }[]
-      | undefined;
-    style?:
-      | {
-          _ref: string;
-          _weak?: boolean | undefined;
-          _strengthenOnPublish?:
-            | {
-                type: string;
-                weak?: boolean | undefined;
-                template?:
-                  | {
-                      id: string;
-                      params: { [x: string]: string | number | boolean };
-                    }
-                  | undefined;
-              }
-            | undefined;
-          _type: "reference";
-          [referenced]: "style";
-          _key: string;
-        }[]
-      | undefined;
-    _id: string;
-    _createdAt: string;
-    _updatedAt: string;
-    _rev: string;
-    id?: string | undefined;
-    images?:
-      | {
-          name: string;
-          description?: string | undefined;
-          asset: {
-            _type: string;
-            _ref: string;
-            _key?: string | undefined;
-            _weak?: boolean | undefined;
-            _strengthenOnPublish?:
-              | {
-                  type: string;
-                  weak?: boolean | undefined;
-                  template?:
-                    | {
-                        id: string;
-                        params: { [x: string]: string | number | boolean };
-                      }
-                    | undefined;
-                }
-              | undefined;
-          };
-          _type: "productImage";
-          _key: string;
-        }[]
-      | undefined;
-    flavour?:
-      | {
-          _ref: string;
-          _weak?: boolean | undefined;
-          _strengthenOnPublish?:
-            | {
-                type: string;
-                weak?: boolean | undefined;
-                template?:
-                  | {
-                      id: string;
-                      params: { [x: string]: string | number | boolean };
-                    }
-                  | undefined;
-              }
-            | undefined;
-          _type: "reference";
-          [referenced]: "flavour";
-          _key: string;
-        }[]
-      | undefined;
-    msrp: number;
-    price: number;
-    _type: "variant";
-  };
-  siteSettings: {
-    title?: string | undefined;
-    description?: string | undefined;
-    _id: string;
-    _createdAt: string;
-    _updatedAt: string;
-    _rev: string;
-    _type: "siteSettings";
-  };
-};
+  export type ContentBlock = NonNullable<Variant["description"]>[0];
+}

--- a/packages/groq-builder/src/types/utils.test.ts
+++ b/packages/groq-builder/src/types/utils.test.ts
@@ -19,15 +19,16 @@ describe("ExtractTypeMismatchErrors", () => {
     type TestObject = {
       FOO: TME<"foo-error">;
       BAR: TME<"bar-error">;
-      BAZ: Valid;
+      BAZ: Valid | TME<"baz-error">;
+      BAT: Valid;
     };
 
     type Result = ExtractTypeMismatchErrors<TestObject>;
 
     expectTypeOf<Result>().toEqualTypeOf<
       | 'Error in "FOO": foo-error'
-      //
       | 'Error in "BAR": bar-error'
+      | 'Error in "BAZ": baz-error'
     >();
   });
   it("should return 'never' when there's no errors", () => {
@@ -49,6 +50,13 @@ describe("RequireAFakeParameterIfThereAreTypeMismatchErrors", () => {
       expected: "EXPECTED";
       actual: "ACTUAL";
     }>;
+    alsoInvalid:
+      | string
+      | TypeMismatchError<{
+          error: "ERROR";
+          expected: "EXPECTED";
+          actual: "ACTUAL";
+        }>;
   };
   it("should return an empty parameter list when there are no errors", () => {
     type Params = RequireAFakeParameterIfThereAreTypeMismatchErrors<NoErrors>;
@@ -58,7 +66,7 @@ describe("RequireAFakeParameterIfThereAreTypeMismatchErrors", () => {
     type Params = RequireAFakeParameterIfThereAreTypeMismatchErrors<WithErrors>;
     expectTypeOf<Params>().toEqualTypeOf<
       | ["⛔️ Error: this projection has type mismatches: ⛔️"]
-      | ['Error in "invalid": ERROR']
+      | ['Error in "invalid": ERROR' | 'Error in "alsoInvalid": ERROR']
     >();
   });
 });

--- a/packages/groq-builder/src/types/utils.ts
+++ b/packages/groq-builder/src/types/utils.ts
@@ -1,4 +1,4 @@
-import type { Simplify } from "type-fest";
+import type { IsNever, Simplify } from "type-fest";
 
 export type { Simplify, Primitive, LiteralUnion, IsAny } from "type-fest";
 
@@ -43,13 +43,15 @@ export type TypeMismatchError<
 /**
  * Extracts all TypeMismatchError's from the projection result,
  * making it easy to report these errors.
- * Returns `never` if there are no errors.
+ * Returns a string of error messages,
+ * or `never` if there are no errors.
  */
 export type ExtractTypeMismatchErrors<TProjectionResult> = ValueOf<{
-  [TKey in StringKeys<keyof TProjectionResult>]: `Error in "${TKey}": ${Extract<
-    TProjectionResult[TKey],
-    TypeMismatchError
-  >["error"]}`;
+  [TKey in StringKeys<
+    keyof TProjectionResult
+  >]: TProjectionResult[TKey] extends TypeMismatchError
+    ? `Error in "${TKey}": ${TProjectionResult[TKey]["error"]}`
+    : never;
 }>;
 
 /**
@@ -117,3 +119,20 @@ export function notNull<T>(value: T | null): value is T {
 export type UndefinedToNull<T> = T extends undefined
   ? NonNullable<T> | null
   : T;
+/**
+ * When we map projection results, we return TypeMismatchError's
+ * for any fields that have an invalid mapping configuration.
+ * However, this does not cause TypeScript to throw any errors.
+ *
+ * In order to get TypeScript to complain about these invalid mappings,
+ * we will "require" an extra parameter, which will reveal the error messages.
+ */
+export type RequireAFakeParameterIfThereAreTypeMismatchErrors<
+  TProjectionResult,
+  _Errors extends string = ExtractTypeMismatchErrors<TProjectionResult>
+> = IsNever<_Errors> extends true
+  ? [] // No errors, yay! Do not require any extra parameters.
+  : // We've got errors; let's require an extra parameter, with the error message:
+    | [Exclude<_Errors, null>]
+      // And this extra error message causes TypeScript to always log the entire list of errors:
+      | ["⛔️ Error: this projection has type mismatches: ⛔️"];

--- a/packages/groq-builder/src/types/utils.ts
+++ b/packages/groq-builder/src/types/utils.ts
@@ -49,8 +49,11 @@ export type TypeMismatchError<
 export type ExtractTypeMismatchErrors<TProjectionResult> = ValueOf<{
   [TKey in StringKeys<
     keyof TProjectionResult
-  >]: TProjectionResult[TKey] extends TypeMismatchError
-    ? `Error in "${TKey}": ${TProjectionResult[TKey]["error"]}`
+  >]: TypeMismatchError extends TProjectionResult[TKey]
+    ? `Error in "${TKey}": ${Extract<
+        TProjectionResult[TKey],
+        TypeMismatchError
+      >["error"]}`
     : never;
 }>;
 
@@ -133,6 +136,6 @@ export type RequireAFakeParameterIfThereAreTypeMismatchErrors<
 > = IsNever<_Errors> extends true
   ? [] // No errors, yay! Do not require any extra parameters.
   : // We've got errors; let's require an extra parameter, with the error message:
-    | [Exclude<_Errors, null>]
+    | [_Errors]
       // And this extra error message causes TypeScript to always log the entire list of errors:
       | ["⛔️ Error: this projection has type mismatches: ⛔️"];


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

When using the built files, the `project` method was causing a TypeScript error, like:
![image](https://github.com/FormidableLabs/groqd/assets/430608/38a5f022-ac52-4863-97ba-f7615ed9f3b7)

This has been fixed, and unit tests added.


Fixes #266 ;) 

#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

### Checklist: (Feel free to delete this section upon completion)

- [x] I have included a changeset if this change will require a version change to one of the packages.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have run all builds, tests, and linting and all checks pass
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
