### PR TITLE
Clear pipeline warnings and remove node16 from pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,30 +18,18 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 18
-
-      - uses: pnpm/action-setup@v2
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v3
         with:
           version: 8.2.0
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        shell: bash
-        run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v3
-        name: Setup pnpm cache
+      - uses: actions/setup-node@v4
         with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: ${{ runner.os }}-pnpm-store-
+          cache: "pnpm"
+          node-version: 18.x
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-
       - name: Build packages
         run: pnpm run build:packages
-
       - name: PR or Publish
         id: changesets
         uses: changesets/action@v1

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -9,35 +9,22 @@ on:
 
 jobs:
   static-analysis:
-    name: 'Lint and Type-check'
+    name: "Lint and Type-check"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 18
-
-      - uses: pnpm/action-setup@v2
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v3
         with:
           version: 8.2.0
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        shell: bash
-        run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v3
-        name: Setup pnpm cache
+      - uses: actions/setup-node@v4
         with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: ${{ runner.os }}-pnpm-store-
+          cache: "pnpm"
+          node-version: 18
       - name: Install dependencies
         run: pnpm install
-
       - name: Build library
         run: pnpm run build:lib
-
       - name: Type Check
         run: pnpm run typecheck
-
       - name: Lint
         run: pnpm run lint

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -8,34 +8,18 @@ on:
   workflow_dispatch:
 
 jobs:
-  matrix:
-    name: 'Node ${{ matrix.node }}'
+  unit-test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node: [16, 18]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node }}
-
-      - uses: pnpm/action-setup@v2
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v3
         with:
           version: 8.2.0
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        shell: bash
-        run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v3
-        name: Setup pnpm cache
+      - uses: actions/setup-node@v4
         with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: ${{ runner.os }}-pnpm-store-
+          cache: "pnpm"
+          node-version: 18
       - name: Install dependencies
         run: pnpm install
-
       - name: Unit Test
         run: pnpm run test
-


### PR DESCRIPTION
As part of the OSS audit, we're trying to clean up the Cicd pipeline warnings and cease usage of node 16 in the pipelines.

Verified the pnpm cache is still working correctly after switching to setup-node caching.

<img width="1219" alt="image" src="https://github.com/FormidableLabs/groqd/assets/3632381/f803b15b-4f95-4347-8bd0-4633e9beef59">


No more warnings:

static-analysis.yml
<img width="1366" alt="image" src="https://github.com/FormidableLabs/groqd/assets/3632381/64596ebe-3c54-453e-8089-69d204bf2049">

unit-test.yml
<img width="898" alt="image" src="https://github.com/FormidableLabs/groqd/assets/3632381/2130ceff-24ab-4a9c-a628-8dc9003c4c5a">


