### PR TITLE
GroqD 1.0 RC - Build config

### DIFF
--- a/.changeset/tall-carrots-give.md
+++ b/.changeset/tall-carrots-give.md
@@ -1,0 +1,12 @@
+---
+"groq-builder": minor
+---
+
+This is the final release before v1.0
+
+## Minor changes
+
+- Configuration: renamed main method from `createGroqBuilder` to `createGroqBuilderLite`
+- Configuration: eliminated need for `ExtractDocumentTypes`
+- Fix: `field` projections handle arrays properly
+- Improvement: better typings for Zod methods

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - groqd-1.0-rc
 
 jobs:
   release:


### PR DESCRIPTION
Updates build config to build off RC branch
Bumps `groq-builder` to `0.10.0` as a "final release"
