### PR TITLE
Fix: support filters after a deref

### DIFF
--- a/.changeset/heavy-penguins-sniff.md
+++ b/.changeset/heavy-penguins-sniff.md
@@ -1,0 +1,6 @@
+---
+"groqd": patch
+---
+
+Fix: ensure `filter` can be chained after a `deref`
+Fixes #323

--- a/packages/groqd/src/commands/filter.ts
+++ b/packages/groqd/src/commands/filter.ts
@@ -25,7 +25,9 @@ declare module "../groq-builder" {
 
 GroqBuilder.implement({
   filter(this: GroqBuilder, filterExpression) {
-    return this.chain(`[${filterExpression}]`);
+    const needsWrap = this.query.endsWith("->");
+    const self = needsWrap ? this.wrap("(", ")") : this;
+    return self.chain(`[${filterExpression}]`);
   },
   filterBy(this: GroqBuilder, filterExpression) {
     return this.filter(filterExpression);

--- a/packages/groqd/src/groq-builder.ts
+++ b/packages/groqd/src/groq-builder.ts
@@ -145,6 +145,20 @@ export class GroqBuilder<
   }
 
   /**
+   * Wraps the current expression with a prefix + suffix.
+   */
+  protected wrap(
+    prefix: string,
+    suffix: string
+  ): GroqBuilder<TResult, TQueryConfig> {
+    return new GroqBuilder<TResult, TQueryConfig>({
+      query: prefix + this.internal.query + suffix,
+      parser: this.internal.parser,
+      options: this.internal.options,
+    });
+  }
+
+  /**
    * Returns an empty GroqBuilder
    */
   public get root() {

--- a/packages/groqd/src/tests/mocks/nextjs-sanity-fe-mocks.ts
+++ b/packages/groqd/src/tests/mocks/nextjs-sanity-fe-mocks.ts
@@ -73,8 +73,8 @@ export class MockFactory {
   variant(
     data: Partial<SanitySchema.Variant>,
     references?: {
-      flavour: SanitySchema.Flavour[];
-      style: SanitySchema.Style[];
+      flavour?: SanitySchema.Flavour[];
+      style?: SanitySchema.Style[];
     }
   ): SanitySchema.Variant {
     const common = this.common("variant");
@@ -84,13 +84,23 @@ export class MockFactory {
       slug: this.slug("variant"),
       name: "Variant Name",
       description: [],
-      flavour: references?.flavour.map((f) => this.reference(f)) ?? [],
+      flavour: references?.flavour?.map((f) => this.reference(f)) ?? [],
       images: [],
       price: 0,
       msrp: 0,
-      style: references?.style.map((s) => this.reference(s)) ?? [],
+      style: references?.style?.map((s) => this.reference(s)) ?? [],
       ...data,
     } satisfies Required<SanitySchema.Variant>;
+  }
+
+  flavour(data: Partial<SanitySchema.Flavour>): SanitySchema.Flavour {
+    const common = this.common("flavour");
+    return {
+      ...common,
+      name: "Flavour Name",
+      slug: this.slug("flavour"),
+      ...data,
+    } satisfies Required<SanitySchema.Flavour>;
   }
 
   image(data: Partial<SanitySchema.ProductImage>): SanitySchema.ProductImage {
@@ -139,12 +149,14 @@ export class MockFactory {
         { categories: categories, variants: variants }
       )
     ),
+    extraData = [],
   }: {
     categories?: SanitySchema.Category[];
     variants?: SanitySchema.Variant[];
     products?: SanitySchema.Product[];
+    extraData?: Array<object>;
   }) {
-    const datalake = [...products, ...categories, ...variants];
+    const datalake = [...products, ...categories, ...variants, ...extraData];
 
     return { products, categories, variants, datalake };
   }

--- a/packages/groqd/src/types/groq-expressions.test.ts
+++ b/packages/groqd/src/types/groq-expressions.test.ts
@@ -203,14 +203,16 @@ describe("Expressions", () => {
 });
 describe("Expressions.Conditional", () => {
   type T = Expressions.Conditional<FooBarBaz, QueryConfig>;
-  type Expected =
-    | "foo == (string)"
-    | `foo == "${string}"`
-    | `bar == (number)`
-    | `bar == ${number}`
-    | `baz == true`
-    | `baz == false`
-    | `baz`
-    | `!baz`;
-  expectTypeOf<T>().toEqualTypeOf<Expected>();
+  it("should include a good list of possible expressions, including booleans", () => {
+    type Expected =
+      | "foo == (string)"
+      | `foo == "${string}"`
+      | `bar == (number)`
+      | `bar == ${number}`
+      | `baz == true`
+      | `baz == false`
+      | `baz`
+      | `!baz`;
+    expectTypeOf<T>().toEqualTypeOf<Expected>();
+  });
 });

--- a/packages/groqd/src/types/groq-expressions.test.ts
+++ b/packages/groqd/src/types/groq-expressions.test.ts
@@ -3,6 +3,8 @@ import { Expressions } from "./groq-expressions";
 import { QueryConfig } from "./schema-types";
 import { Simplify } from "./utils";
 
+type FooBarBaz = { foo: string; bar: number; baz: boolean };
+
 describe("Expressions", () => {
   it("literal values are properly escaped", () => {
     expectTypeOf<
@@ -146,8 +148,7 @@ describe("Expressions", () => {
     });
 
     it("multiple values are compared to same-typed parameters", () => {
-      type Item = { foo: string; bar: number; baz: boolean };
-      type Res = Expressions.Equality<Item, WithVars<ManyParameters>>;
+      type Res = Expressions.Equality<FooBarBaz, WithVars<ManyParameters>>;
       expectTypeOf<Res>().toEqualTypeOf<
         | "foo == $str1"
         | "foo == $str2"
@@ -172,8 +173,7 @@ describe("Expressions", () => {
       };
     };
     it("should work with deeply-nested parameters", () => {
-      type Item = { foo: string; bar: number; baz: boolean };
-      type Res = Expressions.Equality<Item, WithVars<NestedParameters>>;
+      type Res = Expressions.Equality<FooBarBaz, WithVars<NestedParameters>>;
 
       type StandardSuggestions =
         | `foo == (string)`
@@ -200,4 +200,17 @@ describe("Expressions", () => {
       }>();
     });
   });
+});
+describe("Expressions.Conditional", () => {
+  type T = Expressions.Conditional<FooBarBaz, QueryConfig>;
+  type Expected =
+    | "foo == (string)"
+    | `foo == "${string}"`
+    | `bar == (number)`
+    | `bar == ${number}`
+    | `baz == true`
+    | `baz == false`
+    | `baz`
+    | `!baz`;
+  expectTypeOf<T>().toEqualTypeOf<Expected>();
 });

--- a/packages/groqd/src/types/groq-expressions.ts
+++ b/packages/groqd/src/types/groq-expressions.ts
@@ -26,20 +26,31 @@ export namespace Expressions {
    * like '_type == "product"' or 'slug.current == $slug'.
    * */
   export type Conditional<TResultItem, TQueryConfig extends QueryConfig> =
-    // Currently we only support equality expressions:
+    // Currently we only support simple expressions:
     Equality<TResultItem, TQueryConfig> | Booleans<TResultItem>;
 
-  export type Equality<
+  type Comparison<
     TResultItem,
     TQueryConfig extends QueryConfig,
+    _Comparison extends string = "==",
     /** (local use only) Calculate our Parameter entries once, and reuse across suggestions */
     _ParameterEntries = ParameterEntries<TQueryConfig["parameters"]>
   > = ValueOf<{
-    [Key in SuggestedKeys<TResultItem>]: `${Key} == ${SuggestedValues<
+    [Key in SuggestedKeys<TResultItem>]: `${Key} ${_Comparison} ${SuggestedValues<
       _ParameterEntries,
       SuggestedKeysValue<TResultItem, Key>
     >}`;
   }>;
+
+  export type Equality<
+    TResultItem,
+    TQueryConfig extends QueryConfig
+  > = Comparison<TResultItem, TQueryConfig, "==">;
+
+  export type Inequality<
+    TResultItem,
+    TQueryConfig extends QueryConfig
+  > = Comparison<TResultItem, TQueryConfig, "!=">;
 
   type Booleans<TResultItem> = ValueOf<{
     [Key in PathKeysWithType<TResultItem, boolean>]: Key | `!${Key}`;

--- a/packages/groqd/src/types/groq-expressions.ts
+++ b/packages/groqd/src/types/groq-expressions.ts
@@ -1,7 +1,7 @@
 import { QueryConfig } from "./schema-types";
 import type { IsLiteral, LiteralUnion } from "type-fest";
 import { StringKeys, UndefinedToNull, ValueOf } from "./utils";
-import { Path, PathValue } from "./path-types";
+import { Path, PathKeysWithType, PathValue } from "./path-types";
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace Expressions {
@@ -27,7 +27,7 @@ export namespace Expressions {
    * */
   export type Conditional<TResultItem, TQueryConfig extends QueryConfig> =
     // Currently we only support equality expressions:
-    Equality<TResultItem, TQueryConfig>;
+    Equality<TResultItem, TQueryConfig> | Booleans<TResultItem>;
 
   export type Equality<
     TResultItem,
@@ -39,6 +39,10 @@ export namespace Expressions {
       _ParameterEntries,
       SuggestedKeysValue<TResultItem, Key>
     >}`;
+  }>;
+
+  type Booleans<TResultItem> = ValueOf<{
+    [Key in PathKeysWithType<TResultItem, boolean>]: Key | `!${Key}`;
   }>;
 
   // Escape literal values:

--- a/packages/groqd/src/types/path-types.ts
+++ b/packages/groqd/src/types/path-types.ts
@@ -1,5 +1,7 @@
 // Source: https://github.com/toonvanstrijp/nestjs-i18n/blob/1a86bb46e9386c6450d10c9c9e609f78315752d0/src/types.ts
 
+import { ValueOf } from "./utils";
+
 /**
  * Extracts all deep paths of nested types.
  *
@@ -43,6 +45,24 @@ export type PathValue<
 export type PathEntries<TResultItem> = {
   [P in Path<TResultItem>]: PathValue<TResultItem, P>;
 };
+
+/**
+ * Returns all keys that match the specified type.
+ *
+ * @example
+ * PathKeysWithType<{ a: { b: "B", c: 3 }, d: 4}, number> === "a.c" | "d"
+ */
+export type PathKeysWithType<
+  TResultItem,
+  TFilterByType,
+  _Entries = PathEntries<TResultItem>
+> = ValueOf<{
+  [P in keyof _Entries]: _Entries[P] extends TFilterByType
+    ? P
+    : TFilterByType extends _Entries[P]
+    ? P
+    : never;
+}>;
 
 type IsAny<T> = unknown extends T
   ? [keyof T] extends [never]


### PR DESCRIPTION
# What
When calling `.deref().filter(...)`, this code correctly wraps the deref expression in parenthesis.

Addresses #323.

