### PR TITLE
feat(score): adding score command

### DIFF
--- a/packages/groqd/src/commands/filter.test.ts
+++ b/packages/groqd/src/commands/filter.test.ts
@@ -8,7 +8,7 @@ const qVariants = q.star.filterByType("variant");
 
 describe("filter", () => {
   it("should allow for untyped filter expressions", () => {
-    const qAnything = qVariants.filter("ANYTHING");
+    const qAnything = qVariants.filterRaw("ANYTHING");
     expectTypeOf<InferResultType<typeof qAnything>>().toEqualTypeOf<
       Array<SanitySchema.Variant>
     >();
@@ -18,7 +18,7 @@ describe("filter", () => {
   });
 
   const qFiltered = qVariants
-    .filter('name == "FOO"')
+    .filterRaw('name == "FOO"')
     .project({ name: true, id: true });
   const data = mock.generateSeedData({
     variants: [
@@ -29,7 +29,7 @@ describe("filter", () => {
   });
 
   it("should not change the result type", () => {
-    const qFiltered = qVariants.filter("ANYTHING");
+    const qFiltered = qVariants.filterRaw("ANYTHING");
     expectTypeOf<InferResultType<typeof qVariants>>().toEqualTypeOf<
       InferResultType<typeof qFiltered>
     >();
@@ -183,7 +183,7 @@ describe("filterBy", () => {
       flavour: sub
         .field("flavour[]")
         .deref()
-        .filter("defined(name)")
+        .filterRaw("defined(name)")
         .project({ name: true }),
     }));
     it("should add parenthesis around the deref", () => {

--- a/packages/groqd/src/commands/filter.test.ts
+++ b/packages/groqd/src/commands/filter.test.ts
@@ -70,7 +70,7 @@ describe("filterBy", () => {
     qVariants.filterBy("price == 55");
     qVariants.filterBy("id == null");
     qVariants.filterBy('id == "id"');
-    qVariants.filterBy("id == (string)"); // (this is just for auto-complete)
+    qVariants.filterBy('id == "(string)"'); // (this is just for auto-complete)
   });
   it("should not allow mismatched types", () => {
     qVariants.filterBy(

--- a/packages/groqd/src/commands/filter.ts
+++ b/packages/groqd/src/commands/filter.ts
@@ -4,7 +4,36 @@ import { ResultItem } from "../types/result-types";
 
 declare module "../groq-builder" {
   export interface GroqBuilder<TResult, TQueryConfig> {
+    /**
+     * Allows you to write any raw filter expression.
+     * This method is NOT type-checked, but does provide suggestions.
+     *
+     * This is an alias for the `filterRaw` method; please use that instead.
+     *
+     * @deprecated Please use `filterRaw` instead!
+     *
+     * @example
+     * q.star.filterRaw("count(items[]) > 5")
+     *
+     * @param filterExpression - Any valid GROQ expression that can be used for filtering
+     */
     filter(
+      filterExpression: Expressions.AnyConditional<
+        ResultItem.Infer<TResult>,
+        TQueryConfig
+      >
+    ): GroqBuilder<TResult, TQueryConfig>;
+
+    /**
+     * Allows you to write any raw filter expression.
+     * This method is NOT type-checked, but does provide suggestions.
+     *
+     * @example
+     * q.star.filterRaw("count(items[]) > 5")
+     *
+     * @param filterExpression - Any valid GROQ expression that can be used for filtering
+     */
+    filterRaw(
       filterExpression: Expressions.AnyConditional<
         ResultItem.Infer<TResult>,
         TQueryConfig
@@ -25,11 +54,14 @@ declare module "../groq-builder" {
 
 GroqBuilder.implement({
   filter(this: GroqBuilder, filterExpression) {
+    return this.filterRaw(filterExpression);
+  },
+  filterRaw(this: GroqBuilder, filterExpression) {
     const needsWrap = this.query.endsWith("->");
     const self = needsWrap ? this.extend({ query: `(${this.query})` }) : this;
     return self.chain(`[${filterExpression}]`);
   },
   filterBy(this: GroqBuilder, filterExpression) {
-    return this.filter(filterExpression);
+    return this.filterRaw(filterExpression);
   },
 });

--- a/packages/groqd/src/commands/index.ts
+++ b/packages/groqd/src/commands/index.ts
@@ -13,6 +13,7 @@ import "./parameters";
 import "./project";
 import "./projectField";
 import "./raw";
+import "./score";
 import "./select";
 import "./selectByType";
 import "./slice";

--- a/packages/groqd/src/commands/parameters.ts
+++ b/packages/groqd/src/commands/parameters.ts
@@ -1,6 +1,7 @@
 import { GroqBuilder } from "../groq-builder";
 import { Override } from "../types/utils";
 import { Simplify } from "type-fest";
+import { ParametersWith$Sign } from "../types/parameter-types";
 
 declare module "../groq-builder" {
   export interface GroqBuilder<TResult, TQueryConfig> {
@@ -34,6 +35,10 @@ declare module "../groq-builder" {
         {
           // Merge existing parameters with the new parameters:
           parameters: Simplify<TQueryConfig["parameters"] & TParameters>;
+          // Add all these parameters to the scope:
+          scope: Simplify<
+            TQueryConfig["scope"] & ParametersWith$Sign<TParameters>
+          >;
         }
       >
     >;

--- a/packages/groqd/src/commands/score.test.ts
+++ b/packages/groqd/src/commands/score.test.ts
@@ -1,0 +1,52 @@
+import { createGroqBuilderWithZod } from "../index";
+import { SchemaConfig } from "../tests/schemas/nextjs-sanity-fe";
+import { describe, expect, it } from "vitest";
+import { mock } from "../tests/mocks/nextjs-sanity-fe-mocks";
+import { executeBuilder } from "../tests/mocks/executeQuery";
+
+const q = createGroqBuilderWithZod<SchemaConfig>();
+
+const qVariants = q.star.filterByType("variant");
+
+describe("score", () => {
+  const data = mock.generateSeedData({
+    variants: mock.array(10, (i) =>
+      mock.variant({
+        name: i === 5 ? `searched` : `Variant ${i}`,
+      })
+    ),
+  });
+
+  it("score is compiled correctly", () => {
+    const qScore = qVariants.score("price match 100");
+    expect(qScore).toMatchObject({
+      query: `*[_type == "variant"] | score(price match 100)`,
+    });
+  });
+
+  const scoredDataDesc = [
+    data.variants[5],
+    ...data.variants.slice(0, 5),
+    ...data.variants.slice(6),
+  ];
+
+  const scoredDataAsc = [
+    ...data.variants.slice(0, 5),
+    ...data.variants.slice(6),
+    data.variants[5],
+  ];
+
+  it("should execute correctly with ordering desc", async () => {
+    const qScore = qVariants
+      .score('name match "searched"')
+      .order("_score desc");
+    const results = await executeBuilder(qScore, data);
+    expect(results).toMatchObject(scoredDataDesc);
+  });
+
+  it("should execute correctly with ordering asc", async () => {
+    const qScore = qVariants.score('name match "searched"').order("_score asc");
+    const results = await executeBuilder(qScore, data);
+    expect(results).toMatchObject(scoredDataAsc);
+  });
+});

--- a/packages/groqd/src/commands/score.test.ts
+++ b/packages/groqd/src/commands/score.test.ts
@@ -1,59 +1,118 @@
-import { createGroqBuilderWithZod } from "../index";
-import { SchemaConfig } from "../tests/schemas/nextjs-sanity-fe";
-import { describe, expect, it } from "vitest";
+import { InferResultType } from "../index";
+import { q } from "../tests/schemas/nextjs-sanity-fe";
+import { describe, expect, expectTypeOf, it } from "vitest";
 import { mock } from "../tests/mocks/nextjs-sanity-fe-mocks";
 import { executeBuilder } from "../tests/mocks/executeQuery";
-
-const q = createGroqBuilderWithZod<SchemaConfig>();
 
 const qVariants = q.star.filterByType("variant");
 
 describe("score", () => {
   const data = mock.generateSeedData({
-    variants: mock.array(10, (i) =>
-      mock.variant({
-        name: i === 5 ? `searched` : `Variant ${i}`,
-      })
-    ),
+    variants: [
+      mock.variant({ name: "one fish, two fish, red fish, blue fish" }),
+      mock.variant({ name: "the rainbow fish" }),
+      mock.variant({ name: "other" }),
+    ],
   });
 
   it("score is compiled correctly", () => {
-    const qScore = qVariants.score('name match "some name"');
-    expect(qScore).toMatchObject({
-      query: `*[_type == "variant"] | score(name match "some name")`,
-    });
+    const qScore = qVariants.score('name match "fish"');
+    expect(qScore.query).toMatchInlineSnapshot(
+      `"*[_type == "variant"] | score(name match "fish")"`
+    );
   });
 
   it("score is compiled correctly with multiple inputs", () => {
-    const qScore = qVariants.score('name match "test"', 'name match "hi"');
-    expect(qScore).toMatchObject({
-      query: `*[_type == "variant"] | score(name match "test", name match "hi")`,
-    });
+    const qScore = qVariants.score('name match "one"', 'name match "fish"');
+    expect(qScore.query).toMatchInlineSnapshot(
+      `"*[_type == "variant"] | score(name match "one", name match "fish")"`
+    );
   });
 
-  const scoredDataDesc = [
-    data.variants[5],
-    ...data.variants.slice(0, 5),
-    ...data.variants.slice(6),
-  ];
+  const qScore = qVariants
+    .score('name match "fish"')
+    .order("_score desc")
+    .project({
+      name: true,
+      _score: true,
+    });
 
-  const scoredDataAsc = [
-    ...data.variants.slice(0, 5),
-    ...data.variants.slice(6),
-    data.variants[5],
-  ];
+  it("should have the correct type", () => {
+    expectTypeOf<InferResultType<typeof qScore>>().toEqualTypeOf<
+      Array<{
+        name: string;
+        _score: number;
+      }>
+    >();
+  });
 
   it("should execute correctly with ordering desc", async () => {
-    const qScore = qVariants
-      .score('name match "searched"')
-      .order("_score desc");
     const results = await executeBuilder(qScore, data);
-    expect(results).toMatchObject(scoredDataDesc);
+    expect(results).toMatchInlineSnapshot(`
+      [
+        {
+          "_score": 1.6923076923076923,
+          "name": "one fish, two fish, red fish, blue fish",
+        },
+        {
+          "_score": 1,
+          "name": "the rainbow fish",
+        },
+        {
+          "_score": 0,
+          "name": "other",
+        },
+      ]
+    `);
   });
 
   it("should execute correctly with ordering asc", async () => {
-    const qScore = qVariants.score('name match "searched"').order("_score asc");
-    const results = await executeBuilder(qScore, data);
-    expect(results).toMatchObject(scoredDataAsc);
+    const qScoreDesc = qVariants
+      .score('name match "fish"')
+      .order("_score asc")
+      .project({
+        name: true,
+        _score: true,
+      });
+
+    const results = await executeBuilder(qScoreDesc, data);
+    expect(results).toMatchInlineSnapshot(`
+      [
+        {
+          "_score": 0,
+          "name": "other",
+        },
+        {
+          "_score": 1,
+          "name": "the rainbow fish",
+        },
+        {
+          "_score": 1.6923076923076923,
+          "name": "one fish, two fish, red fish, blue fish",
+        },
+      ]
+    `);
+  });
+
+  describe("when projecting", () => {
+    it("should execute correctly", async () => {
+      const results = await executeBuilder(qScore, data);
+      expect(results).toMatchInlineSnapshot(`
+        [
+          {
+            "_score": 1.6923076923076923,
+            "name": "one fish, two fish, red fish, blue fish",
+          },
+          {
+            "_score": 1,
+            "name": "the rainbow fish",
+          },
+          {
+            "_score": 0,
+            "name": "other",
+          },
+        ]
+      `);
+    });
   });
 });

--- a/packages/groqd/src/commands/score.test.ts
+++ b/packages/groqd/src/commands/score.test.ts
@@ -1,5 +1,5 @@
 import { InferResultType } from "../index";
-import { q } from "../tests/schemas/nextjs-sanity-fe";
+import { q, SanitySchema } from "../tests/schemas/nextjs-sanity-fe";
 import { describe, expect, expectTypeOf, it } from "vitest";
 import { mock } from "../tests/mocks/nextjs-sanity-fe-mocks";
 import { executeBuilder } from "../tests/mocks/executeQuery";
@@ -113,6 +113,22 @@ describe("score", () => {
           },
         ]
       `);
+    });
+  });
+
+  describe("scoreRaw", () => {
+    const qScoreRaw = q.star.filterByType("product").scoreRaw("RAW_EXPRESSION");
+
+    it("should allow the raw expression", () => {
+      expect(qScoreRaw.query).toMatchInlineSnapshot(
+        `"*[_type == "product"] | score(RAW_EXPRESSION)"`
+      );
+    });
+
+    it("should have the correct type", () => {
+      expectTypeOf<InferResultType<typeof qScoreRaw>>().toEqualTypeOf<
+        Array<SanitySchema.Product & { _score: number }>
+      >();
     });
   });
 });

--- a/packages/groqd/src/commands/score.test.ts
+++ b/packages/groqd/src/commands/score.test.ts
@@ -94,26 +94,14 @@ describe("score", () => {
     `);
   });
 
-  describe("when projecting", () => {
-    it("should execute correctly", async () => {
-      const results = await executeBuilder(qScore, data);
-      expect(results).toMatchInlineSnapshot(`
-        [
-          {
-            "_score": 1.6923076923076923,
-            "name": "one fish, two fish, red fish, blue fish",
-          },
-          {
-            "_score": 1,
-            "name": "the rainbow fish",
-          },
-          {
-            "_score": 0,
-            "name": "other",
-          },
-        ]
-      `);
-    });
+  it("_score is a field added to the actual items", async () => {
+    const qScoreRaw = qVariants.score('name match "fish"').order("_score desc");
+
+    const results = await executeBuilder(qScoreRaw, data);
+    const firstResult = results[0];
+
+    expectTypeOf(firstResult).toMatchTypeOf<{ _score: number }>();
+    expect(firstResult).toHaveProperty("_score");
   });
 
   describe("scoreRaw", () => {

--- a/packages/groqd/src/commands/score.test.ts
+++ b/packages/groqd/src/commands/score.test.ts
@@ -18,9 +18,16 @@ describe("score", () => {
   });
 
   it("score is compiled correctly", () => {
-    const qScore = qVariants.score("price match 100");
+    const qScore = qVariants.score('name match "some name"');
     expect(qScore).toMatchObject({
-      query: `*[_type == "variant"] | score(price match 100)`,
+      query: `*[_type == "variant"] | score(name match "some name")`,
+    });
+  });
+
+  it("score is compiled correctly with multiple inputs", () => {
+    const qScore = qVariants.score('name match "test"', 'name match "hi"');
+    expect(qScore).toMatchObject({
+      query: `*[_type == "variant"] | score(name match "test", name match "hi")`,
     });
   });
 

--- a/packages/groqd/src/commands/score.ts
+++ b/packages/groqd/src/commands/score.ts
@@ -1,12 +1,16 @@
 import { GroqBuilder } from "../groq-builder";
 import { ResultItem } from "../types/result-types";
+import { Expressions } from "../types/groq-expressions";
+import { StringKeys } from "../types/utils";
 declare module "../groq-builder" {
   export interface GroqBuilder<TResult, TQueryConfig> {
     /**
      * Used to pipe a list of results through the score GROQ function.
      */
-    score(
-      scoringString: string
+    score<TKeys extends StringKeys<keyof ResultItem.Infer<TResult>>>(
+      ...scoringString: Array<
+        Expressions.Matching<ResultItem.Infer<TResult>, TQueryConfig> | TKeys
+      >
     ): GroqBuilder<
       Array<ResultItem.Infer<TResult> & { _score: string }>,
       TQueryConfig
@@ -15,8 +19,8 @@ declare module "../groq-builder" {
 }
 
 GroqBuilder.implement({
-  score(this: GroqBuilder, scoringString) {
-    const query = ` | score(${scoringString})`;
+  score(this: GroqBuilder, ...scoringString) {
+    const query = ` | score(${scoringString.join(", ")})`;
     return this.chain(query);
   },
 });

--- a/packages/groqd/src/commands/score.ts
+++ b/packages/groqd/src/commands/score.ts
@@ -1,0 +1,22 @@
+import { GroqBuilder } from "../groq-builder";
+import { ResultItem } from "../types/result-types";
+declare module "../groq-builder" {
+  export interface GroqBuilder<TResult, TQueryConfig> {
+    /**
+     * Used to pipe a list of results through the score GROQ function.
+     */
+    score(
+      scoringString: string
+    ): GroqBuilder<
+      Array<ResultItem.Infer<TResult> & { _score: string }>,
+      TQueryConfig
+    >;
+  }
+}
+
+GroqBuilder.implement({
+  score(this: GroqBuilder, scoringString) {
+    const query = ` | score(${scoringString})`;
+    return this.chain(query);
+  },
+});

--- a/packages/groqd/src/commands/score.ts
+++ b/packages/groqd/src/commands/score.ts
@@ -1,26 +1,27 @@
 import { GroqBuilder } from "../groq-builder";
 import { ResultItem } from "../types/result-types";
 import { Expressions } from "../types/groq-expressions";
-import { StringKeys } from "../types/utils";
 declare module "../groq-builder" {
   export interface GroqBuilder<TResult, TQueryConfig> {
     /**
      * Used to pipe a list of results through the score GROQ function.
      */
-    score<TKeys extends StringKeys<keyof ResultItem.Infer<TResult>>>(
-      ...scoringString: Array<
-        Expressions.Matching<ResultItem.Infer<TResult>, TQueryConfig> | TKeys
+    score(
+      ...scoringExpressions: Array<
+        Expressions.Score<ResultItem.Infer<TResult>, TQueryConfig>
       >
     ): GroqBuilder<
-      Array<ResultItem.Infer<TResult> & { _score: string }>,
+      ResultItem.Override<
+        TResult,
+        ResultItem.Infer<TResult> & { _score: number }
+      >,
       TQueryConfig
     >;
   }
 }
 
 GroqBuilder.implement({
-  score(this: GroqBuilder, ...scoringString) {
-    const query = ` | score(${scoringString.join(", ")})`;
-    return this.chain(query);
+  score(this: GroqBuilder, ...scoringExpressions) {
+    return this.chain(` | score(${scoringExpressions.join(", ")})`);
   },
 });

--- a/packages/groqd/src/types/groq-expressions.test.ts
+++ b/packages/groqd/src/types/groq-expressions.test.ts
@@ -27,7 +27,7 @@ describe("Expressions", () => {
   it("primitive values are properly typed", () => {
     expectTypeOf<
       Expressions.Equality<{ foo: string }, QueryConfig>
-    >().toEqualTypeOf<`foo == "${string}"` | "foo == (string)">();
+    >().toEqualTypeOf<`foo == "${string}"` | 'foo == "(string)"'>();
     expectTypeOf<
       Expressions.Equality<{ foo: number }, QueryConfig>
     >().toEqualTypeOf<`foo == ${number}` | "foo == (number)">();
@@ -37,6 +37,14 @@ describe("Expressions", () => {
     expectTypeOf<
       Expressions.Equality<{ foo: null }, QueryConfig>
     >().toEqualTypeOf<`foo == null`>();
+  });
+  it("optional values are properly typed", () => {
+    expectTypeOf<
+      Expressions.Equality<{ foo: undefined }, QueryConfig>
+    >().toEqualTypeOf<"foo == null">();
+    expectTypeOf<
+      Expressions.Equality<{ foo?: 999 }, QueryConfig>
+    >().toEqualTypeOf<"foo == null" | "foo == 999" | "foo == (number)">();
   });
 
   it("multiple literals", () => {
@@ -48,7 +56,7 @@ describe("Expressions", () => {
     expectTypeOf<
       Expressions.Equality<{ foo: string; bar: number }, QueryConfig>
     >().toEqualTypeOf<
-      | "foo == (string)"
+      | 'foo == "(string)"'
       | `foo == "${string}"`
       | "bar == (number)"
       | `bar == ${number}`
@@ -70,7 +78,7 @@ describe("Expressions", () => {
       expectTypeOf<
         Expressions.Equality<{ foo: string }, WithParameters<{ str: "FOO" }>>
       >().toEqualTypeOf<
-        `foo == "${string}"` | "foo == (string)" | "foo == $str"
+        `foo == "${string}"` | 'foo == "(string)"' | "foo == $str"
       >();
       expectTypeOf<
         Expressions.Equality<{ bar: number }, WithParameters<{ str: string }>>
@@ -104,7 +112,7 @@ describe("Expressions", () => {
         | 'bar.baz == "BAZ"'
         | "bar.baz == $str"
         | "bar.str == $str"
-        | "bar.str == (string)"
+        | 'bar.str == "(string)"'
         | `bar.str == "${string}"`
         | "bar.num == $num"
         | "bar.num == (number)"
@@ -151,7 +159,7 @@ describe("Expressions", () => {
       expectTypeOf<Res>().toEqualTypeOf<
         | "foo == $str1"
         | "foo == $str2"
-        | "foo == (string)"
+        | 'foo == "(string)"'
         | `foo == "${string}"`
         | "bar == $num1"
         | "bar == (number)"
@@ -178,7 +186,7 @@ describe("Expressions", () => {
       >;
 
       type StandardSuggestions =
-        | `foo == (string)`
+        | 'foo == "(string)"'
         | `foo == "${string}"`
         | `bar == (number)`
         | `bar == ${number}`
@@ -197,7 +205,7 @@ describe("Expressions.Conditional", () => {
   type T = Expressions.Conditional<FooBarBaz, QueryConfig>;
   it("should include a good list of possible expressions, including booleans", () => {
     type Expected =
-      | "foo == (string)"
+      | 'foo == "(string)"'
       | `foo == "${string}"`
       | `bar == (number)`
       | `bar == ${number}`
@@ -214,7 +222,7 @@ describe("Expressions.Score", () => {
   it('should include "match" with suggestions', () => {
     type ExpectedSuggestions =
       // Only string-fields (eg. "foo") should be suggested with "match"
-      `foo match "${string}"` | "foo match (string)";
+      `foo match "${string}"` | 'foo match "(string)"';
 
     type ActualSuggestions = Exclude<ScoreSuggestions, StandardConditionals>;
     expectTypeOf<ActualSuggestions>().toEqualTypeOf<ExpectedSuggestions>();

--- a/packages/groqd/src/types/groq-expressions.ts
+++ b/packages/groqd/src/types/groq-expressions.ts
@@ -21,6 +21,23 @@ export namespace Expressions {
   >;
 
   /**
+   * This type allows any string, but provides
+   * TypeScript suggestions for common expressions,
+   * like '_type == "product"' or 'slug.current == $slug'
+   * and 'title match (string)' for the score command
+   */
+  export type Matching<
+    TResultItem,
+    TQueryConfig extends QueryConfig
+  > = LiteralUnion<
+    // Suggest some equality expressions, like `slug.current == $slug`,
+    // and `title match (string)`
+    Conditional<TResultItem, TQueryConfig> | Match<TResultItem, TQueryConfig>,
+    // but still allow for any string:
+    string
+  >;
+
+  /**
    * A strongly-typed conditional Groq conditional expression.
    * Currently, this only supports simple "equality" expressions,
    * like '_type == "product"' or 'slug.current == $slug'.
@@ -51,6 +68,12 @@ export namespace Expressions {
     TResultItem,
     TQueryConfig extends QueryConfig
   > = Comparison<TResultItem, TQueryConfig, "!=">;
+
+  export type Match<TResultItem, TQueryConfig extends QueryConfig> = Comparison<
+    TResultItem,
+    TQueryConfig,
+    "match"
+  >;
 
   type Booleans<TResultItem> = ValueOf<{
     [Key in PathKeysWithType<TResultItem, boolean>]: Key | `!${Key}`;

--- a/packages/groqd/src/types/groq-expressions.ts
+++ b/packages/groqd/src/types/groq-expressions.ts
@@ -92,6 +92,8 @@ export namespace Expressions {
     ? `"${TValue}"`
     : TValue extends number | boolean | null
     ? TValue
+    : TValue extends undefined
+    ? null
     : never;
 
   /**
@@ -102,7 +104,7 @@ export namespace Expressions {
     ? // If we're already dealing with a literal value, we don't need suggestions:
       never
     : TValue extends string
-    ? "(string)"
+    ? '"(string)"'
     : TValue extends number
     ? "(number)"
     : never;

--- a/packages/groqd/src/types/groq-expressions.ts
+++ b/packages/groqd/src/types/groq-expressions.ts
@@ -1,7 +1,7 @@
 import { QueryConfig } from "./query-config";
-import type { IsLiteral, LiteralUnion } from "type-fest";
-import { StringKeys, UndefinedToNull, ValueOf } from "./utils";
-import { Path, PathKeysWithType, PathValue } from "./path-types";
+import type { ConditionalPick, IsLiteral, LiteralUnion } from "type-fest";
+import { StringKeys, ValueOf } from "./utils";
+import { PathKeysWithType, PathEntries } from "./path-types";
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace Expressions {
@@ -26,16 +26,19 @@ export namespace Expressions {
    * like '_type == "product"' or 'slug.current == $slug'
    * and 'title match (string)' for the score command
    */
-  export type Matching<
+  export type Score<TResultItem, TQueryConfig extends QueryConfig> =
+    // Suggest some equality expressions, like `slug.current == $slug`,
+    | Conditional<TResultItem, TQueryConfig>
+    // and `title match (string)`
+    | MatchExpression<TResultItem, TQueryConfig>;
+
+  /**
+   * Same as Score, but allows any valid string
+   */
+  export type ScoreRaw<
     TResultItem,
     TQueryConfig extends QueryConfig
-  > = LiteralUnion<
-    // Suggest some equality expressions, like `slug.current == $slug`,
-    // and `title match (string)`
-    Conditional<TResultItem, TQueryConfig> | Match<TResultItem, TQueryConfig>,
-    // but still allow for any string:
-    string
-  >;
+  > = LiteralUnion<Score<TResultItem, TQueryConfig>, string>;
 
   /**
    * A strongly-typed conditional Groq conditional expression.
@@ -44,49 +47,57 @@ export namespace Expressions {
    * */
   export type Conditional<TResultItem, TQueryConfig extends QueryConfig> =
     // Currently we only support simple expressions:
-    Equality<TResultItem, TQueryConfig> | Booleans<TResultItem>;
+    Equality<TResultItem, TQueryConfig> | BooleanSuggestions<TResultItem>;
 
   type Comparison<
-    TResultItem,
+    TPathEntries,
     TQueryConfig extends QueryConfig,
-    _Comparison extends string = "==",
-    /** (local use only) Calculate our Parameter entries once, and reuse across suggestions */
-    _ParameterEntries = ParameterEntries<TQueryConfig["parameters"]>
+    _Comparison extends string = "=="
   > = ValueOf<{
-    [Key in SuggestedKeys<TResultItem>]: `${Key} ${_Comparison} ${SuggestedValues<
-      _ParameterEntries,
-      SuggestedKeysValue<TResultItem, Key>
+    [Key in StringKeys<
+      keyof TPathEntries
+    >]: `${Key} ${_Comparison} ${SuggestedKeysByType<
+      TQueryConfig["scope"],
+      TPathEntries[Key]
     >}`;
   }>;
 
   export type Equality<
     TResultItem,
     TQueryConfig extends QueryConfig
-  > = Comparison<TResultItem, TQueryConfig, "==">;
+  > = Comparison<PathEntries<TResultItem>, TQueryConfig, "==">;
 
   export type Inequality<
     TResultItem,
     TQueryConfig extends QueryConfig
-  > = Comparison<TResultItem, TQueryConfig, "!=">;
+  > = Comparison<PathEntries<TResultItem>, TQueryConfig, "!=">;
 
-  export type Match<TResultItem, TQueryConfig extends QueryConfig> = Comparison<
+  export type MatchExpression<
     TResultItem,
+    TQueryConfig extends QueryConfig
+  > = Comparison<
+    ConditionalPick<PathEntries<TResultItem>, string>,
     TQueryConfig,
     "match"
   >;
 
-  type Booleans<TResultItem> = ValueOf<{
+  type BooleanSuggestions<TResultItem> = ValueOf<{
     [Key in PathKeysWithType<TResultItem, boolean>]: Key | `!${Key}`;
   }>;
 
-  // Escape literal values:
+  /**
+   * Suggest literal values:
+   */
   type LiteralValue<TValue> = TValue extends string
     ? `"${TValue}"`
     : TValue extends number | boolean | null
     ? TValue
     : never;
 
-  // Make some literal suggestions:
+  /**
+   * Make some literal suggestions,
+   * like (string) or (number)
+   */
   type LiteralSuggestion<TValue> = IsLiteral<TValue> extends true
     ? // If we're already dealing with a literal value, we don't need suggestions:
       never
@@ -96,29 +107,18 @@ export namespace Expressions {
     ? "(number)"
     : never;
 
-  // Suggest keys:
-  type SuggestedKeys<TResultItem> = Path<TResultItem>;
-  type SuggestedKeysValue<
-    TResultItem,
-    TKey extends SuggestedKeys<TResultItem>
-  > = UndefinedToNull<PathValue<TResultItem, TKey>>;
-
-  type SuggestedValues<TParameterEntries, TValue> =
+  type SuggestedKeysByType<TScope, TValue> =
     // First, suggest parameters:
-    | StringKeysWithType<TParameterEntries, TValue>
+    | KeysByType<PathEntries<TScope>, TValue>
     // Next, make some literal suggestions:
     | LiteralSuggestion<TValue>
-    // Finally, allow all literal values:
+    // Suggest all literal values:
     | LiteralValue<TValue>;
-
-  export type ParameterEntries<TParameters> = {
-    [P in Path<TParameters> as `$${P}`]: PathValue<TParameters, P>;
-  };
 
   /**
    * Finds all (string) keys of TObject where the value matches the given TType
    */
-  export type StringKeysWithType<TObject, TType> = StringKeys<
+  export type KeysByType<TObject, TType> = StringKeys<
     ValueOf<{
       [P in keyof TObject]: TObject[P] extends TType
         ? P

--- a/packages/groqd/src/types/parameter-types.ts
+++ b/packages/groqd/src/types/parameter-types.ts
@@ -1,0 +1,8 @@
+import { StringKeys } from "./utils";
+
+/**
+ * Inside a GROQ query, parameters must be prefixed with $.
+ */
+export type ParametersWith$Sign<T> = {
+  [P in StringKeys<keyof T> as `$${P}`]: T[P];
+};

--- a/packages/groqd/src/types/query-config.ts
+++ b/packages/groqd/src/types/query-config.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/ban-types */
+
 export type QueryConfig = {
   /**
    * This is a union of all possible document types,
@@ -15,5 +17,15 @@ export type QueryConfig = {
    * Represents a map of input parameter names, and their types.
    * To set this, use the `q.parameters<{ id: string }>()` syntax
    */
-  parameters?: {}; // eslint-disable-line @typescript-eslint/ban-types
+  parameters?: {};
+
+  /**
+   * Represents all variables that are currently in-scope.
+   *
+   * This might include:
+   * - Results of the `score()` function (`_score`)
+   * - Parent selector (`^`)
+   * - All parameters (`$id` or `$slug`)
+   */
+  scope?: {};
 };


### PR DESCRIPTION
### Description
Adding the groq [score function](https://www.sanity.io/docs/groq-functions#4798b2cba8df) as a command that adds a pipe score function to the query and adds the new field `_score` to the list of keys in the ResultItem.

There may be two significant things to improve or review here.

First, I do not know if extending the TResult with
```TS
Array<ResultItem.Infer<TResult> & { _score: string }>
```
is the right way to do it.

Secondly, regarding the typing (and probably the naming) of the `scoringString` input parameter, I copied the type from the `filter` method and extended it with the match expression.

So we have to give some responsibility back to the consumer.

The order of the chaining of the commands may also have to be considered.

Fixes #339 

#### Type of Change
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

### How Has This Been Tested?
I added a test file and tested it together with the order command. That might be a violation, but it checks whether the `_score` field is present and correctly filled.

### Checklist: (Feel free to delete this section upon completion)

- [ ] I have included a changeset if this change will require a version change to one of the packages.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have run all builds, tests, and linting and all checks pass
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
