### PR TITLE
Feature: `order` improvements: deep-selection, chainability

### DIFF
--- a/.changeset/wise-bees-impress.md
+++ b/.changeset/wise-bees-impress.md
@@ -1,0 +1,8 @@
+---
+"groqd": patch
+---
+
+Improves several pipe-able methods, like `.order`, `.score`, and `.filter`
+
+- These methods can now come after a projection with validation (eg. `.project(...).score(...).order(...).filter(...)`
+- The `.order` now supports deep selectors.  E.g. `.order("slug.current asc")`

--- a/packages/groqd/src/commands/filter.test.ts
+++ b/packages/groqd/src/commands/filter.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, expectTypeOf } from "vitest";
 import { SanitySchema, q } from "../tests/schemas/nextjs-sanity-fe";
-import { InferResultType } from "../types/public-types";
+import { InferResultItem, InferResultType } from "../types/public-types";
 import { executeBuilder } from "../tests/mocks/executeQuery";
 import { mock } from "../tests/mocks/nextjs-sanity-fe-mocks";
 
@@ -108,6 +108,26 @@ describe("filterBy", () => {
         },
       ]
     `);
+  });
+  it("can filter after a projection", () => {
+    const query = q.star
+      .filterByType("variant")
+      .project({
+        name: q.string(),
+        price: q.number(),
+      })
+      .filterBy("price == 99");
+    expectTypeOf<InferResultItem<typeof query>>().toEqualTypeOf<{
+      name: string;
+      price: number;
+    }>();
+    expect(query.query).toMatchInlineSnapshot(`
+      "*[_type == "variant"] {
+          name,
+          price
+        }[price == 99]"
+    `);
+    expect(query.parser).toBeDefined();
   });
 
   describe("with parameters", () => {

--- a/packages/groqd/src/commands/filter.ts
+++ b/packages/groqd/src/commands/filter.ts
@@ -59,7 +59,7 @@ GroqBuilder.implement({
   filterRaw(this: GroqBuilder, filterExpression) {
     const needsWrap = this.query.endsWith("->");
     const self = needsWrap ? this.extend({ query: `(${this.query})` }) : this;
-    return self.chain(`[${filterExpression}]`);
+    return self.pipe(`[${filterExpression}]`);
   },
   filterBy(this: GroqBuilder, filterExpression) {
     return this.filterRaw(filterExpression);

--- a/packages/groqd/src/commands/filterByType.ts
+++ b/packages/groqd/src/commands/filterByType.ts
@@ -27,6 +27,6 @@ declare module "../groq-builder" {
 
 GroqBuilder.implement({
   filterByType(this: GroqBuilder, ...type) {
-    return this.chain(`[${type.map((t) => `_type == "${t}"`).join(" || ")}]`);
+    return this.pipe(`[${type.map((t) => `_type == "${t}"`).join(" || ")}]`);
   },
 });

--- a/packages/groqd/src/commands/order.test.ts
+++ b/packages/groqd/src/commands/order.test.ts
@@ -40,6 +40,15 @@ describe("order", () => {
       query: `*[_type == "variant"] | order(price)`,
     });
   });
+  it("can query deep types", () => {
+    qVariants.order("slug.current");
+    qVariants.order("slug.current asc");
+    qVariants.order("slug.current desc");
+    // Deeper:
+    const qCatImg = q.star.filterByType("categoryImage");
+    qCatImg.order("images.crop.top");
+    qCatImg.order("images.hotspot.width asc");
+  });
 
   const priceAsc = data.variants.slice().reverse();
   const priceDesc = data.variants.slice();

--- a/packages/groqd/src/commands/order.test.ts
+++ b/packages/groqd/src/commands/order.test.ts
@@ -49,6 +49,22 @@ describe("order", () => {
     qCatImg.order("images.crop.top");
     qCatImg.order("images.hotspot.width asc");
   });
+  it("you can order a query after a validated projection", () => {
+    const query = qVariants
+      .project({
+        name: q.string(),
+      })
+      .order("name");
+    expectTypeOf<InferResultType<typeof query>>().toEqualTypeOf<
+      Array<{ name: string }>
+    >();
+    expect(query.query).toMatchInlineSnapshot(`
+      "*[_type == "variant"] {
+          name
+        } | order(name)"
+    `);
+    expect(query.parser).toBeDefined();
+  });
 
   const priceAsc = data.variants.slice().reverse();
   const priceDesc = data.variants.slice();

--- a/packages/groqd/src/commands/order.ts
+++ b/packages/groqd/src/commands/order.ts
@@ -1,14 +1,14 @@
 import { GroqBuilder } from "../groq-builder";
-import { StringKeys } from "../types/utils";
 import { ResultItem } from "../types/result-types";
+import { Expressions } from "../types/groq-expressions";
 
 declare module "../groq-builder" {
   export interface GroqBuilder<TResult, TQueryConfig> {
     /**
      * Orders the results by the keys specified
      */
-    order<TKeys extends StringKeys<keyof ResultItem.Infer<TResult>>>(
-      ...fields: Array<`${TKeys}${"" | " asc" | " desc"}`>
+    order<TFields extends Expressions.Order<ResultItem.Infer<TResult>>>(
+      ...fields: Array<TFields>
     ): GroqBuilder<TResult, TQueryConfig>;
 
     /** @deprecated Sorting is done via the 'order' method */

--- a/packages/groqd/src/commands/order.ts
+++ b/packages/groqd/src/commands/order.ts
@@ -19,6 +19,6 @@ declare module "../groq-builder" {
 GroqBuilder.implement({
   order(this: GroqBuilder, ...fields) {
     const query = ` | order(${fields.join(", ")})`;
-    return this.chain(query);
+    return this.pipe(query);
   },
 });

--- a/packages/groqd/src/commands/raw.ts
+++ b/packages/groqd/src/commands/raw.ts
@@ -18,6 +18,14 @@ declare module "../groq-builder" {
 }
 GroqBuilder.implement({
   raw(this: GroqBuilder, query, parser) {
-    return this.chain(query, parser);
+    // It's hard to tell if we should use `chain` or `pipe`.
+    // If we supply a parser, then we'll use `.chain`,
+    // to make sure there's no other existing parser.
+    if (parser) {
+      return this.chain(query, parser);
+    }
+    // Otherwise we'll just use the passive `.pipe`:
+    return this.pipe(query);
+    // TODO: consider if we should expose the raw `pipe` and `chain` options instead of this `raw`?
   },
 });

--- a/packages/groqd/src/commands/score.ts
+++ b/packages/groqd/src/commands/score.ts
@@ -45,6 +45,6 @@ GroqBuilder.implement({
     return this.scoreRaw(...scoreExpressions);
   },
   scoreRaw(this: GroqBuilder, ...scoreExpressions) {
-    return this.chain(` | score(${scoreExpressions.join(", ")})`);
+    return this.pipe(` | score(${scoreExpressions.join(", ")})`);
   },
 });

--- a/packages/groqd/src/commands/slice.ts
+++ b/packages/groqd/src/commands/slice.ts
@@ -49,7 +49,7 @@ GroqBuilder.implement({
   slice(this: GroqBuilder, start, end?, inclusive?): GroqBuilder<any> {
     if (typeof end === "number") {
       const ellipsis = inclusive ? ".." : "...";
-      return this.chain(`[${start}${ellipsis}${end}]`);
+      return this.pipe(`[${start}${ellipsis}${end}]`);
     }
     return this.chain(`[${start}]`);
   },

--- a/packages/groqd/src/commands/validate.ts
+++ b/packages/groqd/src/commands/validate.ts
@@ -28,7 +28,9 @@ GroqBuilder.implement({
       this.internal.parser,
       normalizeValidationFunction(parser)
     );
-    return this.chain("", chainedParser);
+    return this.extend({
+      parser: chainedParser,
+    });
   },
   transform(this: GroqBuilder, parser) {
     return this.validate(parser);

--- a/packages/groqd/src/groq-builder.ts
+++ b/packages/groqd/src/groq-builder.ts
@@ -129,13 +129,17 @@ export class GroqBuilder<
 
   /**
    * Returns a new GroqBuilder, appending the query.
+   *
+   * Use this when the query changes the result type.
+   * Use `.pipe` when not changing the result type.
+   *
    * @internal
    */
   protected chain<TResultNew = never>(
     query: string,
     parser?: Parser | null
   ): GroqBuilder<TResultNew, TQueryConfig> {
-    if (query && this.internal.parser) {
+    if (this.internal.parser) {
       /**
        * This happens if you accidentally chain too many times, like:
        *
@@ -162,11 +166,22 @@ export class GroqBuilder<
         }
       );
     }
-
-    return new GroqBuilder({
-      query: this.internal.query + query,
+    return this.extend({
+      query: this.query + query,
       parser: normalizeValidationFunction(parser),
-      options: this.internal.options,
+    });
+  }
+
+  /**
+   * Returns a new GroqBuilder, appending the query.
+   *
+   * This method should be used when NOT changing the result type.  Use `.chain` if you're changing the result type.
+   *
+   * @internal
+   */
+  protected pipe(query: string): GroqBuilder<TResult, TQueryConfig> {
+    return this.extend({
+      query: this.query + query,
     });
   }
 

--- a/packages/groqd/src/types/groq-expressions.test.ts
+++ b/packages/groqd/src/types/groq-expressions.test.ts
@@ -27,7 +27,7 @@ describe("Expressions", () => {
   it("primitive values are properly typed", () => {
     expectTypeOf<
       Expressions.Equality<{ foo: string }, QueryConfig>
-    >().toEqualTypeOf<`foo == "${string}"` | 'foo == "(string)"'>();
+    >().toEqualTypeOf<`foo == "${string}"` | "foo == (string)">();
     expectTypeOf<
       Expressions.Equality<{ foo: number }, QueryConfig>
     >().toEqualTypeOf<`foo == ${number}` | "foo == (number)">();
@@ -56,7 +56,7 @@ describe("Expressions", () => {
     expectTypeOf<
       Expressions.Equality<{ foo: string; bar: number }, QueryConfig>
     >().toEqualTypeOf<
-      | 'foo == "(string)"'
+      | "foo == (string)"
       | `foo == "${string}"`
       | "bar == (number)"
       | `bar == ${number}`
@@ -78,7 +78,7 @@ describe("Expressions", () => {
       expectTypeOf<
         Expressions.Equality<{ foo: string }, WithParameters<{ str: "FOO" }>>
       >().toEqualTypeOf<
-        `foo == "${string}"` | 'foo == "(string)"' | "foo == $str"
+        `foo == "${string}"` | "foo == (string)" | "foo == $str"
       >();
       expectTypeOf<
         Expressions.Equality<{ bar: number }, WithParameters<{ str: string }>>
@@ -112,7 +112,7 @@ describe("Expressions", () => {
         | 'bar.baz == "BAZ"'
         | "bar.baz == $str"
         | "bar.str == $str"
-        | 'bar.str == "(string)"'
+        | "bar.str == (string)"
         | `bar.str == "${string}"`
         | "bar.num == $num"
         | "bar.num == (number)"
@@ -159,7 +159,7 @@ describe("Expressions", () => {
       expectTypeOf<Res>().toEqualTypeOf<
         | "foo == $str1"
         | "foo == $str2"
-        | 'foo == "(string)"'
+        | "foo == (string)"
         | `foo == "${string}"`
         | "bar == $num1"
         | "bar == (number)"
@@ -186,7 +186,7 @@ describe("Expressions", () => {
       >;
 
       type StandardSuggestions =
-        | 'foo == "(string)"'
+        | "foo == (string)"
         | `foo == "${string}"`
         | `bar == (number)`
         | `bar == ${number}`
@@ -205,7 +205,7 @@ describe("Expressions.Conditional", () => {
   type T = Expressions.Conditional<FooBarBaz, QueryConfig>;
   it("should include a good list of possible expressions, including booleans", () => {
     type Expected =
-      | 'foo == "(string)"'
+      | "foo == (string)"
       | `foo == "${string}"`
       | `bar == (number)`
       | `bar == ${number}`
@@ -234,7 +234,7 @@ describe("Expressions.Score", () => {
   it('should include "match" with suggestions', () => {
     type ExpectedSuggestions =
       // Only string-fields (e.g. "foo") should be suggested with "match"
-      `foo match "${string}"` | 'foo match "(string)"';
+      `foo match "${string}"` | "foo match (string)";
 
     type ActualSuggestions = Exclude<ScoreSuggestions, StandardConditionals>;
     expectTypeOf<ActualSuggestions>().toEqualTypeOf<ExpectedSuggestions>();

--- a/packages/groqd/src/types/groq-expressions.test.ts
+++ b/packages/groqd/src/types/groq-expressions.test.ts
@@ -244,3 +244,42 @@ describe("Expressions.Score", () => {
     expectTypeOf<Extra>().toEqualTypeOf<never>();
   });
 });
+describe("Expressions.Order", () => {
+  type SortableType = {
+    str: string;
+    strNull?: string;
+    num: number;
+    numNull?: number;
+    bool: boolean;
+    nested: {
+      str: string;
+    };
+    // Should be ignored:
+    reference: {
+      _type: "reference";
+      _ref: string;
+      _weak?: boolean;
+    };
+    slug: {
+      _type: "slug";
+      current: string;
+      source?: string;
+    };
+  };
+  type ExpectedFields =
+    | "str"
+    | "strNull"
+    | "nested.str"
+    | "slug.current"
+    | "num"
+    | "numNull"
+    | "bool";
+  type Expected =
+    | `${ExpectedFields}`
+    | `${ExpectedFields} asc`
+    | `${ExpectedFields} desc`;
+
+  it("should generate a good list of suggestions", () => {
+    expectTypeOf<Expressions.Order<SortableType>>().toEqualTypeOf<Expected>();
+  });
+});

--- a/packages/groqd/src/types/groq-expressions.ts
+++ b/packages/groqd/src/types/groq-expressions.ts
@@ -107,7 +107,7 @@ export namespace Expressions {
     ? // If we're already dealing with a literal value, we don't need suggestions:
       never
     : TValue extends string
-    ? '"(string)"'
+    ? "(string)"
     : TValue extends number
     ? "(number)"
     : never;

--- a/packages/groqd/src/types/groq-expressions.ts
+++ b/packages/groqd/src/types/groq-expressions.ts
@@ -132,4 +132,20 @@ export namespace Expressions {
         : never;
     }>
   >;
+
+  /**
+   * Returns suggestions for ordering the results.
+   *
+   * @example
+   * Order<Product> ==
+   * | "name" | "name asc" | "name desc"
+   * | "price" | "price asc" | "price desc"
+   * | "slug.current" | "slug.current asc" | "slug.current desc"
+   */
+  export type Order<TResultItem> = `${ProjectionPathsByType<
+    TResultItem,
+    SortableTypes
+  >}${"" | " asc" | " desc"}`;
+
+  type SortableTypes = string | number | boolean | null;
 }

--- a/packages/groqd/src/types/projection-paths.ts
+++ b/packages/groqd/src/types/projection-paths.ts
@@ -104,14 +104,16 @@ export type ProjectionPathsByType<
   T,
   TFilterByType,
   _Entries = ProjectionPathEntries<T>
-> = ValueOf<{
-  [P in keyof _Entries]: TypesAreCompatible<
-    _Entries[P],
-    TFilterByType
-  > extends true
-    ? StringKeys<P>
-    : never;
-}>;
+> = StringKeys<
+  ValueOf<{
+    [P in keyof _Entries]: TypesAreCompatible<
+      _Entries[P],
+      TFilterByType
+    > extends true
+      ? P
+      : never;
+  }>
+>;
 
 export type TypesAreCompatible<A, B> = A extends B
   ? true


### PR DESCRIPTION
Improves several pipe-able methods, like `.order`, `.score`, and `.filter`

- These methods can now come after a projection with validation (eg. `.project(...).score(...).order(...).filter(...)`
- The `.order` now supports deep selectors.  E.g. `.order("slug.current asc")`

Addresses #346 