### PR TITLE
Feature: support `count` and `coalesce` methods

### DIFF
--- a/.changeset/twelve-dolls-cross.md
+++ b/.changeset/twelve-dolls-cross.md
@@ -1,0 +1,7 @@
+---
+"groqd": minor
+---
+
+Feature: added `count` method
+
+Feature: added `coalesce` method

--- a/packages/groqd/src/commands/index.ts
+++ b/packages/groqd/src/commands/index.ts
@@ -1,3 +1,4 @@
+import "./root/count";
 import "./root/fragment";
 import "./root/parameters";
 import "./root/star";

--- a/packages/groqd/src/commands/index.ts
+++ b/packages/groqd/src/commands/index.ts
@@ -1,3 +1,4 @@
+import "./root/coalesce";
 import "./root/count";
 import "./root/fragment";
 import "./root/parameters";

--- a/packages/groqd/src/commands/order.ts
+++ b/packages/groqd/src/commands/order.ts
@@ -18,7 +18,6 @@ declare module "../groq-builder" {
 
 GroqBuilder.implement({
   order(this: GroqBuilder, ...fields) {
-    const query = ` | order(${fields.join(", ")})`;
-    return this.pipe(query);
+    return this.pipe(` | order(${fields.join(", ")})`);
   },
 });

--- a/packages/groqd/src/commands/root/coalesce-types.ts
+++ b/packages/groqd/src/commands/root/coalesce-types.ts
@@ -4,6 +4,10 @@ import { IGroqBuilder } from "../../types/public-types";
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace CoalesceExpressions {
+  /**
+   * Represents the array of args that can be
+   * passed to the `coalesce` method
+   */
   export type CoalesceArgs<TResult> = ArrayMin2<CoalesceArg<TResult>>;
 
   type ArrayMin2<T> = [T, T, ...Array<T>];
@@ -12,6 +16,9 @@ export namespace CoalesceExpressions {
     | keyof ProjectionPathEntries<TResult>
     | IGroqBuilder;
 
+  /**
+   * Extracts the result type from the `coalesce` method
+   */
   export type CoalesceResult<
     TResult,
     TExpressions extends CoalesceArgs<TResult>

--- a/packages/groqd/src/commands/root/coalesce-types.ts
+++ b/packages/groqd/src/commands/root/coalesce-types.ts
@@ -1,0 +1,42 @@
+// eslint-disable-next-line @typescript-eslint/no-namespace
+import { ProjectionPathEntries } from "../../types/projection-paths";
+import { IGroqBuilder } from "../../types/public-types";
+
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace CoalesceExpressions {
+  export type CoalesceArgs<TResult> = ArrayMin2<CoalesceArg<TResult>>;
+
+  type ArrayMin2<T> = [T, T, ...Array<T>];
+
+  type CoalesceArg<TResult> =
+    | keyof ProjectionPathEntries<TResult>
+    | IGroqBuilder;
+
+  export type CoalesceResult<
+    TResult,
+    TExpressions extends CoalesceArgs<TResult>
+  > = CoalesceValues<TResult, TExpressions> extends [
+    ...Array<infer TNullableValues>,
+    infer TFinalValue
+  ]
+    ? NonNullable<TNullableValues> | TFinalValue
+    : never;
+
+  type CoalesceValues<
+    TResult,
+    TExpressions extends CoalesceArgs<TResult>,
+    _PathEntries = ProjectionPathEntries<TResult>
+  > = {
+    [Index in keyof TExpressions]: CoalesceExpressionValue<
+      _PathEntries,
+      TExpressions[Index]
+    >;
+  };
+
+  type CoalesceExpressionValue<PathEntries, TExpression> =
+    TExpression extends IGroqBuilder<infer ExpressionResult>
+      ? ExpressionResult
+      : TExpression extends keyof PathEntries
+      ? PathEntries[TExpression]
+      : never; // (unreachable)
+}

--- a/packages/groqd/src/commands/root/coalesce.test.ts
+++ b/packages/groqd/src/commands/root/coalesce.test.ts
@@ -44,8 +44,15 @@ describe("coalesce", () => {
       });
     });
     it("should execute correctly", async () => {
-      // const productCount = await executeBuilder(qProductCount, data);
-      // expect(productCount).toEqual(data.products.length);
+      const noDataNecessary = { datalake: [] };
+
+      const queryA = q.coalesce(q.value<"A" | null>("A"), q.value("B"));
+      const resultA = await executeBuilder(queryA, noDataNecessary);
+      expect(resultA).toEqual("A");
+
+      const queryB = q.coalesce(q.value<"A" | null>(null), q.value("B"));
+      const resultB = await executeBuilder(queryB, noDataNecessary);
+      expect(resultB).toEqual("B");
     });
   });
 

--- a/packages/groqd/src/commands/root/coalesce.test.ts
+++ b/packages/groqd/src/commands/root/coalesce.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, expectTypeOf } from "vitest";
+import { q, SanitySchema } from "../../tests/schemas/nextjs-sanity-fe";
+import { InferResultItem, InferResultType } from "../../types/public-types";
+import { executeBuilder } from "../../tests/mocks/executeQuery";
+import { mock } from "../../tests/mocks/nextjs-sanity-fe-mocks";
+
+describe("coalesce", () => {
+  const data = mock.generateSeedData({});
+
+  describe("as a root-level query", () => {
+    describe("should have the correct type", () => {
+      it("with literal values", () => {
+        const qAB = q.coalesce(q.value("A"), q.value("B"));
+        expectTypeOf<InferResultType<typeof qAB>>().toEqualTypeOf<"A" | "B">();
+
+        const qABC = q.coalesce(q.value("A"), q.value("B"), q.value("C"));
+        expectTypeOf<InferResultType<typeof qABC>>().toEqualTypeOf<
+          "A" | "B" | "C"
+        >();
+
+        const qA_B = q.coalesce(q.value("A").nullable(), q.value("B"));
+        expectTypeOf<InferResultType<typeof qA_B>>().toEqualTypeOf<"A" | "B">();
+
+        const qA_B_C = q.coalesce(
+          q.value("A").nullable(),
+          q.value("B").nullable(),
+          q.value("C")
+        );
+        expectTypeOf<InferResultType<typeof qA_B_C>>().toEqualTypeOf<
+          "A" | "B" | "C"
+        >();
+
+        const qA_B_C_ = q.coalesce(
+          q.value("A").nullable(),
+          q.value("B").nullable(),
+          q.value("C").nullable()
+        );
+        expectTypeOf<InferResultType<typeof qA_B_C_>>().toEqualTypeOf<
+          "A" | "B" | "C" | null
+        >();
+
+        const qAB_ = q.coalesce(q.value("A"), q.value("B").nullable());
+        expectTypeOf<InferResultType<typeof qAB_>>().toEqualTypeOf<
+          "A" | "B" | null
+        >();
+      });
+    });
+    it("should execute correctly", async () => {
+      // const productCount = await executeBuilder(qProductCount, data);
+      // expect(productCount).toEqual(data.products.length);
+    });
+  });
+
+  describe("in a projection", () => {
+    const qVariants = q.star.filterByType("variant");
+    it("can use a projection string", () => {
+      const qTests = qVariants.project((sub) => ({
+        id_name: sub.coalesce("id", "name"),
+        name_id: sub.coalesce("name", "id"),
+        name_price: sub.coalesce("name", "price"),
+        id_price: sub.coalesce("id", "price"),
+        name_id_price: sub.coalesce("name", "id", "price"),
+      }));
+      expectTypeOf<InferResultItem<typeof qTests>>().toEqualTypeOf<{
+        id_name: string;
+        name_id: string | null;
+        name_price: number | string;
+        id_price: string | number;
+        name_id_price: string | number;
+      }>();
+    });
+    it("can use any nested groq expression", () => {
+      const qTests = qVariants.project((sub) => ({
+        flavour_style: sub.coalesce(
+          sub.field("flavour[]").deref(),
+          sub.field("style[]").deref()
+        ),
+      }));
+      expectTypeOf<InferResultItem<typeof qTests>>().toEqualTypeOf<{
+        flavour_style:
+          | Array<SanitySchema.Flavour>
+          | Array<SanitySchema.Style>
+          | null;
+      }>();
+    });
+
+    it("executes correctly", async () => {
+      // const results = await executeBuilder(q, data);
+      // expect(results).toMatchInlineSnapshot();
+    });
+  });
+});

--- a/packages/groqd/src/commands/root/coalesce.ts
+++ b/packages/groqd/src/commands/root/coalesce.ts
@@ -1,0 +1,71 @@
+import {
+  GroqBuilderBase,
+  GroqBuilderRoot,
+  GroqBuilderSubquery,
+} from "../../groq-builder";
+import { QueryConfig } from "../../types/query-config";
+import { IGroqBuilder, isGroqBuilder } from "../../types/public-types";
+import { ProjectionPathEntries } from "../../types/projection-paths";
+
+declare module "../../groq-builder" {
+  /* eslint-disable @typescript-eslint/no-empty-interface */
+  export interface GroqBuilderRoot<TResult, TQueryConfig>
+    extends CoalesceDefinition<TResult, TQueryConfig> {}
+  export interface GroqBuilderSubquery<TResult, TQueryConfig>
+    extends CoalesceDefinition<TResult, TQueryConfig> {}
+
+  interface CoalesceDefinition<TResult, TQueryConfig extends QueryConfig> {
+    coalesce<TExpressions extends CoalesceArgs<TResult>>(
+      ...expressions: TExpressions
+    ): GroqBuilder<CoalesceResult<TResult, TExpressions>, TQueryConfig>;
+  }
+}
+
+type ArrayMin2<T> = [T, T, ...Array<T>];
+type CoalesceArgs<TResult> = ArrayMin2<CoalesceArg<TResult>>;
+type CoalesceArg<TResult> = keyof ProjectionPathEntries<TResult> | IGroqBuilder;
+
+type CoalesceResult<
+  TResult,
+  TExpressions extends CoalesceArgs<TResult>
+> = CoalesceValues<TResult, TExpressions> extends [
+  ...Array<infer TNullableValues>,
+  infer TFinalValue
+]
+  ? NonNullable<TNullableValues> | TFinalValue
+  : never;
+
+type CoalesceValues<
+  TResult,
+  TExpressions extends CoalesceArgs<TResult>,
+  _PathEntries = ProjectionPathEntries<TResult>
+> = {
+  [Index in keyof TExpressions]: CoalesceExpressionValue<
+    _PathEntries,
+    TExpressions[Index]
+  >;
+};
+
+type CoalesceExpressionValue<PathEntries, TExpression> =
+  TExpression extends IGroqBuilder<infer ExpressionResult>
+    ? ExpressionResult
+    : TExpression extends keyof PathEntries
+    ? PathEntries[TExpression]
+    : never; // (unreachable)
+
+const coalesceImplementation: Pick<
+  GroqBuilderRoot & GroqBuilderSubquery,
+  "coalesce"
+> = {
+  coalesce(
+    this: GroqBuilderBase,
+    ...expressions: Array<IGroqBuilder | string>
+  ) {
+    const queries = expressions.map((expression) =>
+      isGroqBuilder(expression) ? expression.query : expression
+    );
+    return this.chain(`coalesce(${queries.join(", ")})`);
+  },
+};
+GroqBuilderRoot.implement(coalesceImplementation);
+GroqBuilderSubquery.implement(coalesceImplementation);

--- a/packages/groqd/src/commands/root/coalesce.ts
+++ b/packages/groqd/src/commands/root/coalesce.ts
@@ -5,7 +5,10 @@ import {
 } from "../../groq-builder";
 import { QueryConfig } from "../../types/query-config";
 import { IGroqBuilder, isGroqBuilder } from "../../types/public-types";
-import { ProjectionPathEntries } from "../../types/projection-paths";
+import { notNull } from "../../types/utils";
+import { InvalidQueryError } from "../../types/invalid-query-error";
+import { unionParser } from "../../validation/simple-validation";
+import { CoalesceExpressions } from "./coalesce-types";
 
 declare module "../../groq-builder" {
   /* eslint-disable @typescript-eslint/no-empty-interface */
@@ -15,43 +18,14 @@ declare module "../../groq-builder" {
     extends CoalesceDefinition<TResult, TQueryConfig> {}
 
   interface CoalesceDefinition<TResult, TQueryConfig extends QueryConfig> {
-    coalesce<TExpressions extends CoalesceArgs<TResult>>(
+    coalesce<TExpressions extends CoalesceExpressions.CoalesceArgs<TResult>>(
       ...expressions: TExpressions
-    ): GroqBuilder<CoalesceResult<TResult, TExpressions>, TQueryConfig>;
+    ): GroqBuilder<
+      CoalesceExpressions.CoalesceResult<TResult, TExpressions>,
+      TQueryConfig
+    >;
   }
 }
-
-type ArrayMin2<T> = [T, T, ...Array<T>];
-type CoalesceArgs<TResult> = ArrayMin2<CoalesceArg<TResult>>;
-type CoalesceArg<TResult> = keyof ProjectionPathEntries<TResult> | IGroqBuilder;
-
-type CoalesceResult<
-  TResult,
-  TExpressions extends CoalesceArgs<TResult>
-> = CoalesceValues<TResult, TExpressions> extends [
-  ...Array<infer TNullableValues>,
-  infer TFinalValue
-]
-  ? NonNullable<TNullableValues> | TFinalValue
-  : never;
-
-type CoalesceValues<
-  TResult,
-  TExpressions extends CoalesceArgs<TResult>,
-  _PathEntries = ProjectionPathEntries<TResult>
-> = {
-  [Index in keyof TExpressions]: CoalesceExpressionValue<
-    _PathEntries,
-    TExpressions[Index]
-  >;
-};
-
-type CoalesceExpressionValue<PathEntries, TExpression> =
-  TExpression extends IGroqBuilder<infer ExpressionResult>
-    ? ExpressionResult
-    : TExpression extends keyof PathEntries
-    ? PathEntries[TExpression]
-    : never; // (unreachable)
 
 const coalesceImplementation: Pick<
   GroqBuilderRoot & GroqBuilderSubquery,
@@ -64,7 +38,27 @@ const coalesceImplementation: Pick<
     const queries = expressions.map((expression) =>
       isGroqBuilder(expression) ? expression.query : expression
     );
-    return this.chain(`coalesce(${queries.join(", ")})`);
+
+    // Ensure an all-or-nothing approach with the parsers:
+    const maybeParsers = expressions.map((expression) =>
+      isGroqBuilder(expression) ? expression.parser : null
+    );
+    const parsers = maybeParsers.filter(notNull);
+    const hasSomeParsers =
+      parsers.length && parsers.length < expressions.length;
+    if (hasSomeParsers) {
+      const missing = maybeParsers
+        .map((p, i) => (p ? null : queries[i]))
+        .filter(notNull);
+      throw new InvalidQueryError(
+        "COALESCE_MISSING_VALIDATION",
+        `With 'coalesce', you must supply validation for either all, or none, of the expressions.` +
+          ` You did not supply validation for "${missing.join('" or "')}"`
+      );
+    }
+    const parser = !parsers.length ? null : unionParser(parsers);
+
+    return this.chain(`coalesce(${queries.join(", ")})`, parser);
   },
 };
 GroqBuilderRoot.implement(coalesceImplementation);

--- a/packages/groqd/src/commands/root/coalesce.ts
+++ b/packages/groqd/src/commands/root/coalesce.ts
@@ -18,6 +18,21 @@ declare module "../../groq-builder" {
     extends CoalesceDefinition<TResult, TQueryConfig> {}
 
   interface CoalesceDefinition<TResult, TQueryConfig extends QueryConfig> {
+    /**
+     * Wraps the expressions with GROQ's `coalesce(...)` function.
+     *
+     * Each `expression` can be either a projection string, or any valid query.
+     *
+     * @example
+     * q.star.filterByType("product").project(product => ({
+     *   title: product.coalesce(
+     *     "title",
+     *     "category.title",
+     *     product.field("variant").slice(0).deref().field("title"),
+     *     q.value("DEFAULT")
+     *   ),
+     * }));
+     */
     coalesce<TExpressions extends CoalesceExpressions.CoalesceArgs<TResult>>(
       ...expressions: TExpressions
     ): GroqBuilder<

--- a/packages/groqd/src/commands/root/count.test.ts
+++ b/packages/groqd/src/commands/root/count.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, expectTypeOf } from "vitest";
+import { q } from "../../tests/schemas/nextjs-sanity-fe";
+import { InferResultItem, InferResultType } from "../../types/public-types";
+import { executeBuilder } from "../../tests/mocks/executeQuery";
+import { mock } from "../../tests/mocks/nextjs-sanity-fe-mocks";
+
+describe("count", () => {
+  const data = mock.generateSeedData({
+    products: mock.array(3, (i) =>
+      mock.product({
+        images: mock.array(i, () => mock.image({})),
+      })
+    ),
+  });
+
+  describe("as a root-level query", () => {
+    const qProductCount = q.count(q.star.filterByType("product"));
+
+    it("should have the correct type", () => {
+      expectTypeOf<
+        InferResultType<typeof qProductCount>
+      >().toEqualTypeOf<number>();
+    });
+    it("should execute correctly", async () => {
+      const productCount = await executeBuilder(qProductCount, data);
+      expect(productCount).toEqual(data.products.length);
+    });
+  });
+
+  describe("in a projection", () => {
+    const qProducts = q.star.filterByType("product");
+    const qCounts = qProducts.project((product) => ({
+      imageCount: product.count("images[]"),
+    }));
+
+    it("can use a projection string", () => {
+      expectTypeOf<InferResultItem<typeof qCounts>>().toEqualTypeOf<{
+        imageCount: number | null;
+      }>();
+    });
+    it("can use any nested groq expression", () => {
+      const qCounts = qProducts.project((product) => ({
+        imageCount: q.count(product.field("images[].asset").deref()),
+      }));
+      expectTypeOf<InferResultItem<typeof qCounts>>().toEqualTypeOf<{
+        imageCount: number | null;
+      }>();
+    });
+    it("the nested groq expression must be an array", () => {
+      const _qCounts = qProducts.project((product) => ({
+        invalid: q.count(
+          // @ts-expect-error - Type 'number' is not assignable to type 'any[]'
+          product.field("price")
+        ),
+      }));
+    });
+
+    it("executes correctly", async () => {
+      const results = await executeBuilder(qCounts, data);
+      expect(results).toMatchInlineSnapshot(`
+        [
+          {
+            "imageCount": 0,
+          },
+          {
+            "imageCount": 1,
+          },
+          {
+            "imageCount": 2,
+          },
+        ]
+      `);
+    });
+  });
+});

--- a/packages/groqd/src/commands/root/count.ts
+++ b/packages/groqd/src/commands/root/count.ts
@@ -1,0 +1,54 @@
+import {
+  GroqBuilderBase,
+  GroqBuilderRoot,
+  GroqBuilderSubquery,
+} from "../../groq-builder";
+import { IsNullable } from "../../types/utils";
+import { QueryConfig } from "../../types/query-config";
+import { IGroqBuilder, isGroqBuilder } from "../../types/public-types";
+import { Expressions } from "../../types/groq-expressions";
+
+declare module "../../groq-builder" {
+  /* eslint-disable @typescript-eslint/no-empty-interface */
+  export interface GroqBuilderRoot<TResult, TQueryConfig>
+    extends CountDefinition<TResult, TQueryConfig> {}
+  export interface GroqBuilderSubquery<TResult, TQueryConfig>
+    extends CountDefinition<TResult, TQueryConfig> {}
+
+  interface CountDefinition<TResult, TQueryConfig extends QueryConfig> {
+    count<TExpressionResult extends Array<any> | null>(
+      expression: IGroqBuilder<TExpressionResult>
+    ): GroqBuilder<
+      | number
+      // Considering `count(null)` would return `null`:
+      | (IsNullable<TExpressionResult> extends true ? null : never),
+      TQueryConfig
+    >;
+    count<TExpression extends keyof Expressions.CountableEntries<TResult>>(
+      expression: TExpression
+    ): GroqBuilder<
+      | number
+      // Considering `count(null)` would return `null`:
+      | (IsNullable<
+          Expressions.CountableEntries<TResult>[TExpression]
+        > extends true
+          ? null
+          : never),
+      TQueryConfig
+    >;
+  }
+}
+
+const countImplementation: Pick<
+  GroqBuilderRoot & GroqBuilderSubquery,
+  "count"
+> = {
+  count(this: GroqBuilderBase, expression: IGroqBuilder | string) {
+    const query: string = isGroqBuilder(expression)
+      ? expression.query
+      : expression;
+    return this.chain(`count(${query})`);
+  },
+};
+GroqBuilderRoot.implement(countImplementation);
+GroqBuilderSubquery.implement(countImplementation);

--- a/packages/groqd/src/commands/root/count.ts
+++ b/packages/groqd/src/commands/root/count.ts
@@ -16,6 +16,21 @@ declare module "../../groq-builder" {
     extends CountDefinition<TResult, TQueryConfig> {}
 
   interface CountDefinition<TResult, TQueryConfig extends QueryConfig> {
+    /**
+     * Wraps the expressions with GROQ's `count(...)` function.
+     *
+     * The `expression` can be either a projection string, or any valid query.
+     *
+     * @example
+     * q.star.filterByType("product").project(product => ({
+     *   // Use a simple projection string:
+     *   imageCount: product.count("images[]"),
+     *   // Use any complex query:
+     *   categoryCount: product.count(
+     *     product.star.filterByType("category").filterRaw("references(^._id)")
+     *   ),
+     * }));
+     */
     count<TExpressionResult extends Array<any> | null>(
       expression: IGroqBuilder<TExpressionResult>
     ): GroqBuilder<
@@ -24,6 +39,21 @@ declare module "../../groq-builder" {
       | (IsNullable<TExpressionResult> extends true ? null : never),
       TQueryConfig
     >;
+    /**
+     * Wraps the expressions with GROQ's `count(...)` function.
+     *
+     * The `expression` can be either a projection string, or any valid query.
+     *
+     * @example
+     * q.star.filterByType("product").project(product => ({
+     *   // Use a simple projection string:
+     *   imageCount: product.count("images[]"),
+     *   // Use any complex query:
+     *   categoryCount: product.count(
+     *     product.star.filterByType("category").filterRaw("references(^._id)")
+     *   ),
+     * }));
+     */
     count<TExpression extends keyof Expressions.CountableEntries<TResult>>(
       expression: TExpression
     ): GroqBuilder<

--- a/packages/groqd/src/groq-builder/index.test.ts
+++ b/packages/groqd/src/groq-builder/index.test.ts
@@ -12,6 +12,8 @@ describe("GroqBuilderRoot", () => {
       | "star"
       | "project"
       | "raw"
+      | "count"
+      | "coalesce"
       // Utils:
       | "value"
       | "parameters"
@@ -43,6 +45,8 @@ describe("GroqBuilderSubquery", () => {
       | "asType"
       | "raw"
       // Subquery utils:
+      | "count"
+      | "coalesce"
       | "conditional"
       | "conditionalByType"
       | "select"

--- a/packages/groqd/src/tests/schemas/nextjs-sanity-fe.ts
+++ b/packages/groqd/src/tests/schemas/nextjs-sanity-fe.ts
@@ -3,9 +3,9 @@ import {
   internalGroqTypeReferenceTo,
 } from "./nextjs-sanity-fe.sanity-typegen";
 import * as SanitySchema from "./nextjs-sanity-fe.sanity-typegen";
-import { createGroqBuilderWithZod } from "../../index";
+import { createGroqBuilderWithZod, zod } from "../../index";
 
-export { SanitySchema };
+export { SanitySchema, zod };
 
 export type ReferenceTo<TypeName extends string> = {
   _ref: string;

--- a/packages/groqd/src/types/compatible-types.test.ts
+++ b/packages/groqd/src/types/compatible-types.test.ts
@@ -1,0 +1,58 @@
+import { describe, expectTypeOf, it } from "vitest";
+import { CompatibleKeys, TypesAreCompatible } from "./compatible-types";
+
+describe("CompatibleKeys", () => {
+  type TestType = {
+    str: string;
+    strLiteral: "literal";
+    strNull: string | null;
+    strOpt?: string;
+    num: number;
+    numNull: number | null;
+    numOpt?: number;
+    arrStr: Array<string>;
+    arrNum: Array<number>;
+    arrNull: Array<number> | null;
+  };
+  it("should work for literals", () => {
+    expectTypeOf<CompatibleKeys<TestType, string>>().toEqualTypeOf<
+      "str" | "strLiteral"
+    >();
+    expectTypeOf<CompatibleKeys<TestType, "literal">>().toEqualTypeOf<
+      "str" | "strLiteral"
+    >();
+    expectTypeOf<CompatibleKeys<TestType, "FOO">>().toEqualTypeOf<"str">();
+    expectTypeOf<CompatibleKeys<TestType, number>>().toEqualTypeOf<"num">();
+  });
+  it("should work for nulls", () => {
+    expectTypeOf<CompatibleKeys<TestType, null>>().toEqualTypeOf<never>();
+    expectTypeOf<CompatibleKeys<TestType, string | null>>().toEqualTypeOf<
+      "str" | "strLiteral" | "strNull"
+    >();
+  });
+  it("should work for arrays", () => {
+    expectTypeOf<CompatibleKeys<TestType, Array<any>>>().toEqualTypeOf<
+      "arrStr" | "arrNum"
+    >();
+    expectTypeOf<
+      CompatibleKeys<TestType, Array<string>>
+    >().toEqualTypeOf<"arrStr">();
+    expectTypeOf<CompatibleKeys<TestType, Array<any> | null>>().toEqualTypeOf<
+      "arrStr" | "arrNum" | "arrNull"
+    >();
+    expectTypeOf<
+      CompatibleKeys<TestType, Array<number> | null>
+    >().toEqualTypeOf<"arrNum" | "arrNull">();
+  });
+});
+describe("TypesAreCompatible", () => {
+  it("should work for literals", () => {
+    expectTypeOf<TypesAreCompatible<string, "str">>().toEqualTypeOf<true>();
+    expectTypeOf<TypesAreCompatible<"str", string>>().toEqualTypeOf<true>();
+
+    // Should not be compatible:
+    expectTypeOf<TypesAreCompatible<"str", "other">>().toEqualTypeOf<false>();
+    expectTypeOf<TypesAreCompatible<"str", number>>().toEqualTypeOf<false>();
+    expectTypeOf<TypesAreCompatible<number, "str">>().toEqualTypeOf<false>();
+  });
+});

--- a/packages/groqd/src/types/compatible-types.ts
+++ b/packages/groqd/src/types/compatible-types.ts
@@ -1,0 +1,24 @@
+/**
+ * Picks all the keys where the value is compatible with the Condition type.
+ */
+export type CompatiblePick<Base, Condition> = Pick<
+  Base,
+  CompatibleKeys<Base, Condition>
+>;
+/**
+ * Returns all keys, where the value is compatible with the Condition type.
+ */
+export type CompatibleKeys<Base, Condition> = {
+  [Key in keyof Base]-?: TypesAreCompatible<Base[Key], Condition> extends true
+    ? Key
+    : never;
+}[keyof Base];
+/**
+ * Returns true if A and B are compatible types, like strings, literals, numbers, etc.
+ *
+ */
+export type TypesAreCompatible<A, B> = A extends B
+  ? true
+  : B extends A
+  ? true
+  : false;

--- a/packages/groqd/src/types/groq-expressions.test.ts
+++ b/packages/groqd/src/types/groq-expressions.test.ts
@@ -2,6 +2,7 @@ import { describe, expectTypeOf, it } from "vitest";
 import { Expressions } from "./groq-expressions";
 import { QueryConfig } from "./query-config";
 import { ParametersWith$Sign } from "./parameter-types";
+import { SanitySchema } from "../tests/schemas/nextjs-sanity-fe";
 
 type FooBarBaz = { foo: string; bar: number; baz: boolean };
 
@@ -281,5 +282,20 @@ describe("Expressions.Order", () => {
 
   it("should generate a good list of suggestions", () => {
     expectTypeOf<Expressions.Order<SortableType>>().toEqualTypeOf<Expected>();
+  });
+});
+describe("Expressions.Countable", () => {
+  it("should generate a good list of suggestions", () => {
+    type ActualSuggestions =
+      keyof Expressions.CountableEntries<SanitySchema.Variant>;
+    type Expected =
+      | "description[]"
+      ///
+      | "images[]"
+      | "flavour[]"
+      | "style[]";
+    type Missing = Exclude<ActualSuggestions, Expected>;
+    expectTypeOf<Missing>().toEqualTypeOf<never>();
+    expectTypeOf<ActualSuggestions>().toEqualTypeOf<Expected>();
   });
 });

--- a/packages/groqd/src/types/groq-expressions.ts
+++ b/packages/groqd/src/types/groq-expressions.ts
@@ -3,6 +3,7 @@ import type { ConditionalPick, IsLiteral, LiteralUnion } from "type-fest";
 import { StringKeys, ValueOf } from "./utils";
 import {
   ProjectionPathEntries,
+  ProjectionPathEntriesByType,
   ProjectionPathsByType,
 } from "./projection-paths";
 
@@ -148,4 +149,12 @@ export namespace Expressions {
   >}${"" | " asc" | " desc"}`;
 
   type SortableTypes = string | number | boolean | null;
+
+  export type CountableEntries<TResult> = PickByKey<
+    ProjectionPathEntriesByType<TResult, Array<any> | null>,
+    `${string}[]` // We only want "actual" arrays, not nested ones
+  >;
+  type PickByKey<T, Key> = {
+    [P in Extract<keyof T, Key>]: T[P];
+  };
 }

--- a/packages/groqd/src/types/projection-paths.test.ts
+++ b/packages/groqd/src/types/projection-paths.test.ts
@@ -37,28 +37,25 @@ describe("ProjectionPaths", () => {
   });
 
   it("should generate keys for array types", () => {
-    expectTypeOf<ProjectionPaths<{ a: [] }>>().toEqualTypeOf<"a" | "a[]">();
+    expectTypeOf<ProjectionPaths<{ a: unknown[] }>>().toEqualTypeOf<"a[]">();
     expectTypeOf<ProjectionPaths<{ a: Array<{ b: "B" }> }>>().toEqualTypeOf<
-      "a" | "a[]" | "a[].b"
+      "a[]" | "a[].b"
     >();
     expectTypeOf<
       ProjectionPaths<{ a: Array<{ b: Array<{ c: "C" }> }> }>
     >().toEqualTypeOf<
-      | "a"
-      ///
       | "a[]"
-      | "a[].b"
+      ///
       | "a[].b[]"
       | "a[].b[].c"
     >();
     expectTypeOf<
       ProjectionPaths<{ a: Array<Array<{ b: "B" }>> }>
     >().toEqualTypeOf<
-      | "a"
-      ///
       | "a[]"
-      | "a[][].b"
+      ///
       | "a[][]"
+      | "a[][].b"
     >();
   });
 
@@ -103,14 +100,8 @@ describe("ProjectionPathValue", () => {
   });
 
   it("should return the correct types from array paths", () => {
-    expectTypeOf<ProjectionPathValue<TestObject, "g">>().toEqualTypeOf<
-      Array<{ h: Array<{ i: "I" }> }>
-    >();
     expectTypeOf<ProjectionPathValue<TestObject, "g[]">>().toEqualTypeOf<
       Array<{ h: Array<{ i: "I" }> }>
-    >();
-    expectTypeOf<ProjectionPathValue<TestObject, "g[].h">>().toEqualTypeOf<
-      Array<Array<{ i: "I" }>>
     >();
     expectTypeOf<ProjectionPathValue<TestObject, "g[].h[]">>().toEqualTypeOf<
       Array<Array<{ i: "I" }>>
@@ -202,7 +193,6 @@ describe("ProjectionPathEntries", () => {
         a: Array<string>;
       }>
     >().toEqualTypeOf<{
-      a: Array<string>;
       "a[]": Array<string>;
     }>();
 
@@ -211,7 +201,6 @@ describe("ProjectionPathEntries", () => {
         a: Array<{ foo: "FOO" }>;
       }>
     >().toEqualTypeOf<{
-      a: Array<{ foo: "FOO" }>;
       "a[]": Array<{ foo: "FOO" }>;
       "a[].foo": Array<"FOO">;
     }>();
@@ -253,7 +242,6 @@ describe("ProjectionPathEntries", () => {
         a?: Array<{ b: "B" }>;
       }>
     >().toEqualTypeOf<{
-      a: null | Array<{ b: "B" }>;
       "a[]": null | Array<{ b: "B" }>;
       "a[].b": null | Array<"B">;
     }>();
@@ -300,15 +288,11 @@ describe("ProjectionPathEntries", () => {
         "slug.current": string;
 
         // These are references, so they don't go deeper:
-        description: null | V["description"];
         "description[]": null | V["description"];
-        flavour: null | V["flavour"];
         "flavour[]": null | V["flavour"];
-        style: null | V["style"];
         "style[]": null | V["style"];
 
         // Images get expanded pretty deep:
-        images: null | Array<ProductImage>;
         "images[]": null | Array<ProductImage>;
         "images[]._type": null | Array<"productImage">;
         "images[]._key": null | Array<string>;

--- a/packages/groqd/src/types/projection-paths.test.ts
+++ b/packages/groqd/src/types/projection-paths.test.ts
@@ -4,7 +4,6 @@ import {
   ProjectionPaths,
   ProjectionPathsByType,
   ProjectionPathValue,
-  TypesAreCompatible,
 } from "./projection-paths";
 import { SanitySchema } from "../tests/schemas/nextjs-sanity-fe";
 import { Slug } from "../tests/schemas/nextjs-sanity-fe.sanity-typegen";
@@ -365,16 +364,5 @@ describe("ProjectionPathEntries", () => {
         "crop.right": null | number;
       }>();
     });
-  });
-});
-describe("TypesAreCompatible", () => {
-  it("should work for literals", () => {
-    expectTypeOf<TypesAreCompatible<string, "str">>().toEqualTypeOf<true>();
-    expectTypeOf<TypesAreCompatible<"str", string>>().toEqualTypeOf<true>();
-
-    // Should not be compatible:
-    expectTypeOf<TypesAreCompatible<"str", "other">>().toEqualTypeOf<false>();
-    expectTypeOf<TypesAreCompatible<"str", number>>().toEqualTypeOf<false>();
-    expectTypeOf<TypesAreCompatible<number, "str">>().toEqualTypeOf<false>();
   });
 });

--- a/packages/groqd/src/types/result-types.ts
+++ b/packages/groqd/src/types/result-types.ts
@@ -1,4 +1,4 @@
-import { IsNullable, Override as _Override } from "./utils";
+import { IsNullable, MakeNullable, Override as _Override } from "./utils";
 
 /* eslint-disable @typescript-eslint/no-namespace */
 
@@ -72,7 +72,7 @@ export namespace ResultItem {
  * @internal Only exported for tests
  */
 export namespace ResultUtils {
-  type Unwrapped = {
+  export type Unwrapped = {
     TResultItem: unknown;
     IsArray: boolean;
     IsNullable: boolean;
@@ -94,9 +94,6 @@ export namespace ResultUtils {
   >;
 
   // Internal utils:
-  type MakeNullable<IsNullable extends boolean, T> = IsNullable extends true
-    ? null | T
-    : T;
   type MakeArray<IsArray extends boolean, T> = IsArray extends true
     ? Array<T>
     : T;

--- a/packages/groqd/src/types/utils.ts
+++ b/packages/groqd/src/types/utils.ts
@@ -121,6 +121,14 @@ export type IsNullable<T> = null extends T
   : false;
 
 /**
+ * Makes a type nullable
+ */
+export type MakeNullable<
+  IsNullable extends boolean,
+  T
+> = IsNullable extends true ? null | T : T;
+
+/**
  * Returns just one type from a union of types.
  *
  * Note: ⚠️ the order is determined by compiler internals, and is NOT very stable!  Tread carefully!

--- a/packages/groqd/src/validation/simple-validation.ts
+++ b/packages/groqd/src/validation/simple-validation.ts
@@ -174,7 +174,7 @@ export function unionParser<TItemInput, TItemOutput>(
       null,
       input,
       new Error(
-        `Expected the value to match one of the values above, but got ${inspect(
+        `Expected the value to match one of the values above, but got: ${inspect(
           input
         )}`
       )


### PR DESCRIPTION
Adds `q.count(expression)` and `q.coalesce(...expressions)` methods.

Implements #295.

Fully tested by unit tests.