### PR TITLE
Fix: always require `[]` when projecting arrays

### DIFF
--- a/.changeset/shiny-lemons-end.md
+++ b/.changeset/shiny-lemons-end.md
@@ -1,0 +1,9 @@
+---
+"groqd": patch
+---
+
+Fix: always require `[]` when projecting arrays.
+
+- Prevents issues with chaining `.deref()` and `.field()`
+- Makes code clearer
+- Reduces noise in auto-complete suggestions

--- a/packages/groqd/src/commands/filter.test.ts
+++ b/packages/groqd/src/commands/filter.test.ts
@@ -257,4 +257,23 @@ describe("filterBy", () => {
       `);
     });
   });
+
+  describe("when used in a projection", () => {
+    type VariantImage = NonNullable<SanitySchema.Variant["images"]>[number];
+    const query = q.star.filterByType("variant").project((variant) => ({
+      images: variant.field("images[]").filterBy("asset == null"),
+    }));
+    it("should generate a valid query", () => {
+      expect(query.query).toMatchInlineSnapshot(`
+        "*[_type == "variant"] {
+            "images": images[][asset == null]
+          }"
+      `);
+    });
+    it("should have a valid result type", () => {
+      expectTypeOf<InferResultItem<typeof query>>().toEqualTypeOf<{
+        images: null | Array<VariantImage>;
+      }>();
+    });
+  });
 });

--- a/packages/groqd/src/types/projection-paths.test.ts
+++ b/packages/groqd/src/types/projection-paths.test.ts
@@ -38,28 +38,25 @@ describe("ProjectionPaths", () => {
   });
 
   it("should generate keys for array types", () => {
-    expectTypeOf<ProjectionPaths<{ a: [] }>>().toEqualTypeOf<"a" | "a[]">();
+    expectTypeOf<ProjectionPaths<{ a: unknown[] }>>().toEqualTypeOf<"a[]">();
     expectTypeOf<ProjectionPaths<{ a: Array<{ b: "B" }> }>>().toEqualTypeOf<
-      "a" | "a[]" | "a[].b"
+      "a[]" | "a[].b"
     >();
     expectTypeOf<
       ProjectionPaths<{ a: Array<{ b: Array<{ c: "C" }> }> }>
     >().toEqualTypeOf<
-      | "a"
-      ///
       | "a[]"
-      | "a[].b"
+      ///
       | "a[].b[]"
       | "a[].b[].c"
     >();
     expectTypeOf<
       ProjectionPaths<{ a: Array<Array<{ b: "B" }>> }>
     >().toEqualTypeOf<
-      | "a"
-      ///
       | "a[]"
-      | "a[][].b"
+      ///
       | "a[][]"
+      | "a[][].b"
     >();
   });
 
@@ -104,14 +101,8 @@ describe("ProjectionPathValue", () => {
   });
 
   it("should return the correct types from array paths", () => {
-    expectTypeOf<ProjectionPathValue<TestObject, "g">>().toEqualTypeOf<
-      Array<{ h: Array<{ i: "I" }> }>
-    >();
     expectTypeOf<ProjectionPathValue<TestObject, "g[]">>().toEqualTypeOf<
       Array<{ h: Array<{ i: "I" }> }>
-    >();
-    expectTypeOf<ProjectionPathValue<TestObject, "g[].h">>().toEqualTypeOf<
-      Array<Array<{ i: "I" }>>
     >();
     expectTypeOf<ProjectionPathValue<TestObject, "g[].h[]">>().toEqualTypeOf<
       Array<Array<{ i: "I" }>>
@@ -203,7 +194,6 @@ describe("ProjectionPathEntries", () => {
         a: Array<string>;
       }>
     >().toEqualTypeOf<{
-      a: Array<string>;
       "a[]": Array<string>;
     }>();
 
@@ -212,7 +202,6 @@ describe("ProjectionPathEntries", () => {
         a: Array<{ foo: "FOO" }>;
       }>
     >().toEqualTypeOf<{
-      a: Array<{ foo: "FOO" }>;
       "a[]": Array<{ foo: "FOO" }>;
       "a[].foo": Array<"FOO">;
     }>();
@@ -254,7 +243,6 @@ describe("ProjectionPathEntries", () => {
         a?: Array<{ b: "B" }>;
       }>
     >().toEqualTypeOf<{
-      a: null | Array<{ b: "B" }>;
       "a[]": null | Array<{ b: "B" }>;
       "a[].b": null | Array<"B">;
     }>();
@@ -301,15 +289,11 @@ describe("ProjectionPathEntries", () => {
         "slug.current": string;
 
         // These are references, so they don't go deeper:
-        description: null | V["description"];
         "description[]": null | V["description"];
-        flavour: null | V["flavour"];
         "flavour[]": null | V["flavour"];
-        style: null | V["style"];
         "style[]": null | V["style"];
 
         // Images get expanded pretty deep:
-        images: null | Array<ProductImage>;
         "images[]": null | Array<ProductImage>;
         "images[]._type": null | Array<"productImage">;
         "images[]._key": null | Array<string>;

--- a/packages/groqd/src/types/projection-paths.ts
+++ b/packages/groqd/src/types/projection-paths.ts
@@ -15,7 +15,6 @@ import {
  * since they're rarely traversed into
  */
 export type ProjectionPathIgnoreTypes =
-  | Primitive
   | { _type: "reference" }
   | { _type: "block" };
 
@@ -37,38 +36,50 @@ export type ProjectionPathEntries<Value> = IsAny<Value> extends true
   ? // For <any> types, we just allow any string values:
     Record<string, any>
   : Simplify<
-      UnionToIntersectionFast<_ProjectionPathEntries<SimplifyUnion<Value>>>
+      UnionToIntersectionFast<_ProjectionPathEntries<"", SimplifyUnion<Value>>>
     >;
 
+type IsShallowType<Value> = IsAny<Value> extends true
+  ? true
+  : IsNever<Value> extends true
+  ? true
+  : Value extends Primitive
+  ? true
+  : Value extends ProjectionPathIgnoreTypes
+  ? true
+  : false;
+
 // The actual implementation:
-type _ProjectionPathEntries<Value, CurrentPath extends string = ""> =
-  // If it's one of these simple types, we don't need to include any entries:
-  IsAny<Value> extends true
-    ? never
-    : IsNever<Value> extends true
-    ? never
-    : Value extends ProjectionPathIgnoreTypes
+type _ProjectionPathEntries<CurrentPath extends string, Value> =
+  // If it's one of these simple types, we don't need to include any deeper entries:
+  IsShallowType<Value> extends true
     ? never
     : Value extends { _type: "slug" }
     ? Record<JoinPath<CurrentPath, "current">, string>
     : // Check for Arrays:
     Value extends Array<infer U>
     ?
-        | Record<CurrentPath | `${CurrentPath}[]`, Value>
+        | Record<`${CurrentPath}[]`, Value>
         | (_ProjectionPathEntries<
-            UndefinedToNull<U>,
-            `${CurrentPath}[]`
+            `${CurrentPath}[]`,
+            UndefinedToNull<U>
           > extends infer ChildEntries
             ? ValuesAsArrays<ChildEntries>
             : never)
     : // It must be an object; let's map it:
       ValueOf<{
-        // Calculate the NewPath:
-        [Key in StringKeyOf<Value>]:  // Include the current entry:
-          | Record<JoinPath<CurrentPath, Key>, UndefinedToNull<Value[Key]>>
-          // Include all child entries:
+        [Key in StringKeys<keyof Value>]:
+          | (IsArray<Value[Key]> extends true
+              ? never // We want arrays to require the `[]`
+              : // Include an entry for the current item:
+                Record<JoinPath<CurrentPath, Key>, UndefinedToNull<Value[Key]>>)
+
+          // Include all nested entries:
           | ValuesAsMaybeNullable<
-              _ProjectionPathEntries<Value[Key], JoinPath<CurrentPath, Key>>,
+              _ProjectionPathEntries<
+                JoinPath<CurrentPath, Key>,
+                UndefinedToNull<Value[Key]>
+              >,
               IsNullable<Value[Key]>
             >;
       }>;
@@ -77,7 +88,6 @@ type JoinPath<
   CurrentPath extends string,
   Key extends string
 > = `${CurrentPath}${CurrentPath extends "" ? "" : "."}${Key}`;
-type StringKeyOf<T> = Extract<keyof T, string>;
 type ValuesAsArrays<T> = {
   [P in keyof T]: Array<T[P]>;
 };
@@ -90,7 +100,16 @@ type ValuesAsMaybeNullable<
       [P in keyof T]: null | T[P];
     };
 
-export type ProjectionPaths<T> = StringKeyOf<ProjectionPathEntries<T>>;
+type IsArray<T> = IsAny<T> extends true
+  ? false
+  : Array<any> extends T
+  ? true
+  : false;
+
+/**
+ * Retrieves all projection paths for the given T
+ */
+export type ProjectionPaths<T> = StringKeys<keyof ProjectionPathEntries<T>>;
 
 export type ProjectionPathValue<
   T,


### PR DESCRIPTION
This PR forces array projections to require the `[]` braces.
This fixes potential problems with chaining `.deref()` or `.field()` off an Array.
It also helps to support future runtime validation.