### PR TITLE
Feature: added "passthrough" parameter for `raw`

### DIFF
--- a/.changeset/lemon-peaches-kneel.md
+++ b/.changeset/lemon-peaches-kneel.md
@@ -1,0 +1,5 @@
+---
+"groqd": patch
+---
+
+Feature: added "passthrough" parameter for `raw`

--- a/packages/groqd/src/commands/filter.ts
+++ b/packages/groqd/src/commands/filter.ts
@@ -59,7 +59,7 @@ GroqBuilder.implement({
   filterRaw(this: GroqBuilder, filterExpression) {
     const needsWrap = this.query.endsWith("->");
     const self = needsWrap ? this.extend({ query: `(${this.query})` }) : this;
-    return self.pipe(`[${filterExpression}]`);
+    return self.chain(`[${filterExpression}]`, "passthrough");
   },
   filterBy(this: GroqBuilder, filterExpression) {
     return this.filterRaw(filterExpression);

--- a/packages/groqd/src/commands/filterByType.ts
+++ b/packages/groqd/src/commands/filterByType.ts
@@ -27,6 +27,9 @@ declare module "../groq-builder" {
 
 GroqBuilder.implement({
   filterByType(this: GroqBuilder, ...type) {
-    return this.pipe(`[${type.map((t) => `_type == "${t}"`).join(" || ")}]`);
+    return this.chain(
+      `[${type.map((t) => `_type == "${t}"`).join(" || ")}]`,
+      "passthrough"
+    );
   },
 });

--- a/packages/groqd/src/commands/order.ts
+++ b/packages/groqd/src/commands/order.ts
@@ -18,6 +18,6 @@ declare module "../groq-builder" {
 
 GroqBuilder.implement({
   order(this: GroqBuilder, ...fields) {
-    return this.pipe(` | order(${fields.join(", ")})`);
+    return this.chain(` | order(${fields.join(", ")})`, "passthrough");
   },
 });

--- a/packages/groqd/src/commands/raw.ts
+++ b/packages/groqd/src/commands/raw.ts
@@ -5,14 +5,34 @@ declare module "../groq-builder" {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   export interface GroqBuilderBase<TResult, TQueryConfig> {
     /**
-     * An "escape hatch" allowing you to write any groq query you want.
-     * You must specify a type parameter for the new results.
+     * This is an "escape hatch" allowing you to write any groq query you want.
      *
-     * This should only be used for unsupported features, since it bypasses all strongly-typed inputs.
+     * To ensure the correct result type,
+     * you must either provide a validation function,
+     * or specify the type parameter manually.
+     *
+     * This should only be used for unsupported features,
+     * since it ignores the schema.
+     *
+     * @example
+     * q.star.filterByType("user").project({
+     *   name: q.raw('firstName + " " + lastName', zod.string()),
+     *   tags: q.raw<string>('array::join(tags, ", ")'),
+     * })
+     *
+     * @param query - This raw GROQ query gets appended to the current query
+     * @param parser - A function that validates the incoming data.
+     *                 Use "passthrough" to indicate that it's OK for
+     *                 the previous parser to be used with this new data
+     *                 (i.e. the raw query doesn't change the result type).
      */
-    raw<TResultNew = never>(
+    raw<TResultNew = unknown>(
       query: string,
-      parser?: Parser<unknown, TResultNew> | null | "passthrough"
+      parser?: Parser<unknown, TResultNew> | null
+    ): GroqBuilder<TResultNew, TQueryConfig>;
+    raw<TResultNew = TResult>(
+      query: string,
+      parser: "passthrough"
     ): GroqBuilder<TResultNew, TQueryConfig>;
   }
 }

--- a/packages/groqd/src/commands/raw.ts
+++ b/packages/groqd/src/commands/raw.ts
@@ -12,21 +12,13 @@ declare module "../groq-builder" {
      */
     raw<TResultNew = never>(
       query: string,
-      parser?: Parser<unknown, TResultNew> | null
+      parser?: Parser<unknown, TResultNew> | null | "passthrough"
     ): GroqBuilder<TResultNew, TQueryConfig>;
   }
 }
 const rawImplementation: Pick<GroqBuilderBase, "raw"> = {
   raw(this: GroqBuilderBase, query, parser) {
-    // It's hard to tell if we should use `chain` or `pipe`.
-    // If we supply a parser, then we'll use `.chain`,
-    // to make sure there's no other existing parser.
-    if (parser) {
-      return this.chain(query, parser);
-    }
-    // Otherwise we'll just use the passive `.pipe`:
-    return this.pipe(query);
-    // TODO: consider if we should expose the raw `pipe` and `chain` options instead of this `raw`?
+    return this.chain(query, parser);
   },
 };
 GroqBuilderBase.implement(rawImplementation);

--- a/packages/groqd/src/commands/score.ts
+++ b/packages/groqd/src/commands/score.ts
@@ -45,6 +45,9 @@ GroqBuilder.implement({
     return this.scoreRaw(...scoreExpressions);
   },
   scoreRaw(this: GroqBuilder, ...scoreExpressions) {
-    return this.pipe(` | score(${scoreExpressions.join(", ")})`);
+    return this.chain(
+      ` | score(${scoreExpressions.join(", ")})`,
+      "passthrough"
+    );
   },
 });

--- a/packages/groqd/src/commands/slice.ts
+++ b/packages/groqd/src/commands/slice.ts
@@ -49,7 +49,7 @@ GroqBuilder.implement({
   slice(this: GroqBuilder, start, end?, inclusive?): GroqBuilder<any> {
     if (typeof end === "number") {
       const ellipsis = inclusive ? ".." : "...";
-      return this.pipe(`[${start}${ellipsis}${end}]`);
+      return this.chain(`[${start}${ellipsis}${end}]`, "passthrough");
     }
     return this.chain(`[${start}]`);
   },

--- a/packages/groqd/src/groq-builder/index.ts
+++ b/packages/groqd/src/groq-builder/index.ts
@@ -68,9 +68,9 @@ export class GroqBuilderBase<
    */
   protected chain<TResultNew = TResult>(
     query: string,
-    parser?: Parser | null
+    parser?: Parser | null | "passthrough"
   ): GroqBuilder<TResultNew, TQueryConfig> {
-    if (this.internal.parser) {
+    if (this.internal.parser && parser !== "passthrough") {
       /**
        * This happens if you accidentally chain too many times, like:
        *
@@ -99,20 +99,10 @@ export class GroqBuilderBase<
     }
     return this.extend({
       query: this.internal.query + query,
-      parser: normalizeValidationFunction(parser),
-    });
-  }
-
-  /**
-   * Returns a new GroqBuilder, appending the query.
-   *
-   * This method should be used when NOT changing the result type.  Use `.chain` if you're changing the result type.
-   *
-   * @internal
-   */
-  protected pipe(query: string): GroqBuilder<TResult, TQueryConfig> {
-    return this.extend({
-      query: this.internal.query + query,
+      parser:
+        parser === "passthrough"
+          ? this.internal.parser
+          : normalizeValidationFunction(parser),
     });
   }
 

--- a/packages/groqd/src/groq-builder/index.ts
+++ b/packages/groqd/src/groq-builder/index.ts
@@ -61,10 +61,12 @@ export class GroqBuilderBase<
   /**
    * Returns a new GroqBuilder, appending the query.
    *
-   * Use this when the query changes the result type.
-   * Use `.pipe` when not changing the result type.
-   *
    * @internal
+   * @param query - This raw GROQ query gets appended to the current query
+   * @param parser - A function that validates the incoming data.
+   *                 Use "passthrough" to indicate that it's OK for
+   *                 the previous parser to be used with this new data
+   *                 (i.e. the raw query doesn't change the result type).
    */
   protected chain<TResultNew = TResult>(
     query: string,


### PR DESCRIPTION
The `raw` method previously tried to detect whether or not it should pass through previous parsers.
Instead, this PR adds an option to pass the string `"passthrough"` to explicitly allow this behavior.

This PR also removes the internal `pipe` method, replacing it with ths "passthrough" feature.