### PR TITLE
Fix: ensure we can get fields from blocks and references

### DIFF
--- a/.changeset/hungry-ligers-provide.md
+++ b/.changeset/hungry-ligers-provide.md
@@ -1,0 +1,5 @@
+---
+"groqd": patch
+---
+
+Fix: ensure we can get fields from `block` and `reference` objects

--- a/packages/groqd/src/tests/mocks/nextjs-sanity-fe-mocks.ts
+++ b/packages/groqd/src/tests/mocks/nextjs-sanity-fe-mocks.ts
@@ -152,6 +152,8 @@ export class MockFactory {
       children: [{ _type: "span", _key: "", text: "", marks: [] }],
       markDefs: [],
       style: undefined,
+      listItem: undefined,
+      level: undefined,
       ...data,
     };
   }

--- a/packages/groqd/src/types/projection-paths.ts
+++ b/packages/groqd/src/types/projection-paths.ts
@@ -13,23 +13,34 @@ import { CompatibleKeys, CompatiblePick } from "./compatible-types";
 
 /**
  * These types are ignored when calculating projection paths,
- * since they're rarely traversed into
+ * since they're rarely traversed into.
+ *
+ * This interface is extensible, if you want to add your
+ * own shallow types.
  */
-export type ProjectionPathIgnoreTypes =
-  | { _type: "reference" }
-  | { _type: "block" };
+export interface ProjectionPathShallowTypes {
+  "reference blocks": { _type: "reference" };
+  "portable text blocks": { _type: "block" };
+}
+
+type ShouldBeShallow<Value, CurrentPath> =
+  // When at the top-level, we should allow deep nesting:
+  CurrentPath extends ""
+    ? false
+    : // These types should not be deeply-traversed:
+    NonNullable<Value> extends ValueOf<ProjectionPathShallowTypes>
+    ? true
+    : false;
 
 /**
  * These simple types are shallow, and do not need to
  * include any deeper entries.
  */
-type IsShallowType<Value> = IsAny<Value> extends true
+type IsSimpleType<Value> = IsAny<Value> extends true
   ? true
   : IsNever<Value> extends true
   ? true
   : Value extends Primitive
-  ? true
-  : Value extends ProjectionPathIgnoreTypes
   ? true
   : false;
 
@@ -58,7 +69,9 @@ export type ProjectionPathEntries<Value> = IsAny<Value> extends true
 type _ProjectionPathEntries<
   CurrentPath extends string,
   Value
-> = IsShallowType<Value> extends true
+> = IsSimpleType<Value> extends true
+  ? never
+  : ShouldBeShallow<Value, CurrentPath> extends true
   ? never
   : Value extends { _type: "slug" }
   ? Record<JoinPath<CurrentPath, "current">, string>


### PR DESCRIPTION
Addresses #369 

The `field(name)` method normally allows deeply-nested fields, but ignores `reference` and `block` types.

This PR allows for deeply-nested fields for `reference` and `block` types when at the top-level.

Example:
```ts
q.fragment<Article>().project(sub => ({
  content: sub.field("content[]").project((txt) => ({
    children: txt.field("children[]"),
    markDefs: txt.field("markDefs[]"),
  })
});
```