### PR TITLE
Feature: support "query syntax" in conditionals

### DIFF
--- a/.changeset/dry-elephants-collect.md
+++ b/.changeset/dry-elephants-collect.md
@@ -1,0 +1,6 @@
+---
+"groqd": minor
+---
+
+Feature: support "query syntax" in conditionals
+Feature: support `.value(...)` and `.star` at the subquery level

--- a/packages/groqd/.eslintrc
+++ b/packages/groqd/.eslintrc
@@ -1,5 +1,6 @@
 {
   "rules": {
+    "@typescript-eslint/no-empty-interface": "off",
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-namespace": "off",
 

--- a/packages/groqd/src/commands/root/coalesce.ts
+++ b/packages/groqd/src/commands/root/coalesce.ts
@@ -1,4 +1,5 @@
 import {
+  GroqBuilder,
   GroqBuilderBase,
   GroqBuilderRoot,
   GroqBuilderSubquery,
@@ -11,41 +12,36 @@ import { CoalesceExpressions } from "./coalesce-types";
 import { IGroqBuilder, isGroqBuilder } from "../../groq-builder";
 
 declare module "../../groq-builder" {
-  /* eslint-disable @typescript-eslint/no-empty-interface */
   export interface GroqBuilderRoot<TResult, TQueryConfig>
     extends CoalesceDefinition<TResult, TQueryConfig> {}
   export interface GroqBuilderSubquery<TResult, TQueryConfig>
     extends CoalesceDefinition<TResult, TQueryConfig> {}
-
-  interface CoalesceDefinition<TResult, TQueryConfig extends QueryConfig> {
-    /**
-     * Wraps the expressions with GROQ's `coalesce(...)` function.
-     *
-     * Each `expression` can be either a projection string, or any valid query.
-     *
-     * @example
-     * q.star.filterByType("product").project(product => ({
-     *   title: product.coalesce(
-     *     "title",
-     *     "category.title",
-     *     product.field("variant").slice(0).deref().field("title"),
-     *     q.value("DEFAULT")
-     *   ),
-     * }));
-     */
-    coalesce<TExpressions extends CoalesceExpressions.CoalesceArgs<TResult>>(
-      ...expressions: TExpressions
-    ): GroqBuilder<
-      CoalesceExpressions.CoalesceResult<TResult, TExpressions>,
-      TQueryConfig
-    >;
-  }
 }
 
-const coalesceImplementation: Pick<
-  GroqBuilderRoot & GroqBuilderSubquery,
-  "coalesce"
-> = {
+interface CoalesceDefinition<TResult, TQueryConfig extends QueryConfig> {
+  /**
+   * Wraps the expressions with GROQ's `coalesce(...)` function.
+   *
+   * Each `expression` can be either a projection string, or any valid query.
+   *
+   * @example
+   * q.star.filterByType("product").project(product => ({
+   *   title: product.coalesce(
+   *     "title",
+   *     "category.title",
+   *     product.field("variant").slice(0).deref().field("title"),
+   *     q.value("DEFAULT")
+   *   ),
+   * }));
+   */
+  coalesce<TExpressions extends CoalesceExpressions.CoalesceArgs<TResult>>(
+    ...expressions: TExpressions
+  ): GroqBuilder<
+    CoalesceExpressions.CoalesceResult<TResult, TExpressions>,
+    TQueryConfig
+  >;
+}
+const coalesceImplementation: CoalesceDefinition<any, any> = {
   coalesce(
     this: GroqBuilderBase,
     ...expressions: Array<IGroqBuilder | string>

--- a/packages/groqd/src/commands/root/count.ts
+++ b/packages/groqd/src/commands/root/count.ts
@@ -1,4 +1,5 @@
 import {
+  GroqBuilder,
   GroqBuilderBase,
   GroqBuilderRoot,
   GroqBuilderSubquery,
@@ -9,70 +10,65 @@ import { Expressions } from "../../types/groq-expressions";
 import { IGroqBuilder, isGroqBuilder } from "../../groq-builder";
 
 declare module "../../groq-builder" {
-  /* eslint-disable @typescript-eslint/no-empty-interface */
   export interface GroqBuilderRoot<TResult, TQueryConfig>
     extends CountDefinition<TResult, TQueryConfig> {}
   export interface GroqBuilderSubquery<TResult, TQueryConfig>
     extends CountDefinition<TResult, TQueryConfig> {}
-
-  interface CountDefinition<TResult, TQueryConfig extends QueryConfig> {
-    /**
-     * Wraps the expressions with GROQ's `count(...)` function.
-     *
-     * The `expression` can be either a projection string, or any valid query.
-     *
-     * @example
-     * q.star.filterByType("product").project(product => ({
-     *   // Use a simple projection string:
-     *   imageCount: product.count("images[]"),
-     *   // Use any complex query:
-     *   categoryCount: product.count(
-     *     product.star.filterByType("category").filterRaw("references(^._id)")
-     *   ),
-     * }));
-     */
-    count<TExpressionResult extends Array<any> | null>(
-      expression: IGroqBuilder<TExpressionResult>
-    ): GroqBuilder<
-      | number
-      // Considering `count(null)` would return `null`:
-      | (IsNullable<TExpressionResult> extends true ? null : never),
-      TQueryConfig
-    >;
-    /**
-     * Wraps the expressions with GROQ's `count(...)` function.
-     *
-     * The `expression` can be either a projection string, or any valid query.
-     *
-     * @example
-     * q.star.filterByType("product").project(product => ({
-     *   // Use a simple projection string:
-     *   imageCount: product.count("images[]"),
-     *   // Use any complex query:
-     *   categoryCount: product.count(
-     *     product.star.filterByType("category").filterRaw("references(^._id)")
-     *   ),
-     * }));
-     */
-    count<TExpression extends keyof Expressions.CountableEntries<TResult>>(
-      expression: TExpression
-    ): GroqBuilder<
-      | number
-      // Considering `count(null)` would return `null`:
-      | (IsNullable<
-          Expressions.CountableEntries<TResult>[TExpression]
-        > extends true
-          ? null
-          : never),
-      TQueryConfig
-    >;
-  }
 }
 
-const countImplementation: Pick<
-  GroqBuilderRoot & GroqBuilderSubquery,
-  "count"
-> = {
+interface CountDefinition<TResult, TQueryConfig extends QueryConfig> {
+  /**
+   * Wraps the expressions with GROQ's `count(...)` function.
+   *
+   * The `expression` can be either a projection string, or any valid query.
+   *
+   * @example
+   * q.star.filterByType("product").project(product => ({
+   *   // Use a simple projection string:
+   *   imageCount: product.count("images[]"),
+   *   // Use any complex query:
+   *   categoryCount: product.count(
+   *     product.star.filterByType("category").filterRaw("references(^._id)")
+   *   ),
+   * }));
+   */
+  count<TExpressionResult extends Array<any> | null>(
+    expression: IGroqBuilder<TExpressionResult>
+  ): GroqBuilder<
+    | number
+    // Considering `count(null)` would return `null`:
+    | (IsNullable<TExpressionResult> extends true ? null : never),
+    TQueryConfig
+  >;
+  /**
+   * Wraps the expressions with GROQ's `count(...)` function.
+   *
+   * The `expression` can be either a projection string, or any valid query.
+   *
+   * @example
+   * q.star.filterByType("product").project(product => ({
+   *   // Use a simple projection string:
+   *   imageCount: product.count("images[]"),
+   *   // Use any complex query:
+   *   categoryCount: product.count(
+   *     product.star.filterByType("category").filterRaw("references(^._id)")
+   *   ),
+   * }));
+   */
+  count<TExpression extends keyof Expressions.CountableEntries<TResult>>(
+    expression: TExpression
+  ): GroqBuilder<
+    | number
+    // Considering `count(null)` would return `null`:
+    | (IsNullable<
+        Expressions.CountableEntries<TResult>[TExpression]
+      > extends true
+        ? null
+        : never),
+    TQueryConfig
+  >;
+}
+const countImplementation: CountDefinition<any, any> = {
   count(this: GroqBuilderBase, expression: IGroqBuilder | string) {
     const query: string = isGroqBuilder(expression)
       ? expression.query

--- a/packages/groqd/src/commands/root/star.test.ts
+++ b/packages/groqd/src/commands/root/star.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, expectTypeOf } from "vitest";
-import { SchemaConfig, q } from "../../tests/schemas/nextjs-sanity-fe";
+import {
+  SchemaConfig,
+  q,
+  SanitySchema,
+} from "../../tests/schemas/nextjs-sanity-fe";
 import { SchemaDocument } from "../../types/document-types";
 import { executeBuilder } from "../../tests/mocks/executeQuery";
 import { mock } from "../../tests/mocks/nextjs-sanity-fe-mocks";
@@ -18,6 +22,16 @@ describe("star", () => {
     expect(star).toMatchObject({
       query: "*",
     });
+  });
+  it("sub-queries can be started with '*'", () => {
+    const subQuery = q.star.filterByType("category").project((sub) => ({
+      products: sub.star.filterByType("product").filterBy("references(^._id)"),
+    }));
+    expectTypeOf<InferResultType<typeof subQuery>>().toEqualTypeOf<
+      Array<{
+        products: Array<SanitySchema.Product>;
+      }>
+    >();
   });
 
   describe("execution", () => {

--- a/packages/groqd/src/commands/root/star.ts
+++ b/packages/groqd/src/commands/root/star.ts
@@ -1,28 +1,40 @@
-import { GroqBuilderRoot } from "../../groq-builder";
+import {
+  GroqBuilder,
+  GroqBuilderBase,
+  GroqBuilderRoot,
+  GroqBuilderSubquery,
+} from "../../groq-builder";
 import { SchemaDocument } from "../../types/document-types";
+import { QueryConfig } from "../../types/query-config";
 
 declare module "../../groq-builder" {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  export interface GroqBuilderRoot<TResult, TQueryConfig> {
-    /**
-     * Selects all documents, via GROQ's `*` selector.
-     * This is how most queries start.
-     *
-     * @example
-     * q.star.filter(...).project(...)
-     *
-     */
-    star: GroqBuilder<
-      Array<Extract<TQueryConfig["schemaTypes"], SchemaDocument>>,
-      TQueryConfig
-    >;
-  }
+  export interface GroqBuilderRoot<TResult, TQueryConfig>
+    extends StarDefinition<TResult, TQueryConfig> {}
+  export interface GroqBuilderSubquery<TResult, TQueryConfig>
+    extends StarDefinition<TResult, TQueryConfig> {}
 }
 
-GroqBuilderRoot.implementProperties({
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+interface StarDefinition<TResult, TQueryConfig extends QueryConfig> {
+  /**
+   * Selects all documents, via GROQ's `*` selector.
+   * This is how most queries start.
+   *
+   * @example
+   * q.star.filter(...).project(...)
+   *
+   */
+  star: GroqBuilder<
+    Array<Extract<TQueryConfig["schemaTypes"], SchemaDocument>>,
+    TQueryConfig
+  >;
+}
+const starImplementation = {
   star: {
-    get(this: GroqBuilderRoot) {
+    get(this: GroqBuilderBase) {
       return this.chain("*");
     },
   },
-});
+};
+GroqBuilderRoot.implementProperties(starImplementation);
+GroqBuilderSubquery.implementProperties(starImplementation);

--- a/packages/groqd/src/commands/root/value.ts
+++ b/packages/groqd/src/commands/root/value.ts
@@ -1,26 +1,36 @@
-import { GroqBuilderRoot } from "../../groq-builder";
+import {
+  GroqBuilder,
+  GroqBuilderRoot,
+  GroqBuilderSubquery,
+} from "../../groq-builder";
 import { Parser } from "../../types/parser-types";
+import { QueryConfig } from "../../types/query-config";
 
 declare module "../../groq-builder" {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  export interface GroqBuilderRoot<TResult, TQueryConfig> {
-    /**
-     * Returns a literal Groq value, properly escaped.
-     * @param value
-     * @param validation
-     */
-    value<T extends LiteralValueTypes>(
-      value: T,
-      validation?: Parser<T, T> | null
-    ): GroqBuilder<T, TQueryConfig>;
-  }
+  export interface GroqBuilderRoot<TResult, TQueryConfig>
+    extends ValueDefinition<TResult, TQueryConfig> {}
+  export interface GroqBuilderSubquery<TResult, TQueryConfig>
+    extends ValueDefinition<TResult, TQueryConfig> {}
 }
 
-GroqBuilderRoot.implement({
+interface ValueDefinition<_TResult, TQueryConfig extends QueryConfig> {
+  /**
+   * Returns a literal Groq value, properly escaped.
+   * @param value
+   * @param validation
+   */
+  value<T extends LiteralValueTypes>(
+    value: T,
+    validation?: Parser<T, T> | null
+  ): GroqBuilder<T, TQueryConfig>;
+}
+const valueImplementation: ValueDefinition<any, any> = {
   value(this: GroqBuilderRoot, value, validation = null) {
     return this.chain(escapeValue(value), validation);
   },
-});
+};
+GroqBuilderRoot.implement(valueImplementation);
+GroqBuilderSubquery.implement(valueImplementation);
 
 export type LiteralValueTypes = string | boolean | number | null;
 

--- a/packages/groqd/src/commands/subquery/conditional-types.ts
+++ b/packages/groqd/src/commands/subquery/conditional-types.ts
@@ -1,7 +1,6 @@
 import {
   ExtractProjectionResult,
   ProjectionMap,
-  ProjectionMapOrCallback,
 } from "../../types/projection-types";
 import {
   Empty,
@@ -18,15 +17,43 @@ import { IGroqBuilder, InferResultType } from "../../groq-builder";
 export type ConditionalProjectionMap<
   TResultItem,
   TQueryConfig extends QueryConfig
-> = Partial<
-  Record<
-    Expressions.AnyConditional<TResultItem, TQueryConfig>,
-    | ProjectionMap<TResultItem, TQueryConfig>
-    | ((
-        sub: GroqBuilderSubquery<TResultItem, TQueryConfig>
-      ) => ProjectionMap<TResultItem, TQueryConfig>)
-  >
->;
+> = {
+  [P in Expressions.AnyConditional<
+    TResultItem,
+    TQueryConfig
+  >]?: ConditionalQuery<TResultItem, TQueryConfig>;
+};
+
+/**
+ * The ConditionalQuery can be one of these values:
+ * @example
+ * q.conditional({
+ *   // a Raw Projection:
+ *   "condition1": { slug: "slug.current" },
+ *   // a Query (for some edge-cases):
+ *   "condition2": q.project({ slug: "slug.current" }),
+ *   // a function that returns either a Raw Projection or a Query:
+ *   "condition3": (q) => ({ slug: "slug.current" }),
+ *   "condition4": (q) => q.project({ slug: "slug.current" }),
+ * })
+ *
+ * @example
+ * ...q.conditionalByType({
+ *   link: { href: true },
+ *   // The "callback" syntax allows `q` to be strongly-typed:
+ *   button: q => ({ href: q.field("url") })
+ *   reference: q => q.field("@").deref().project({ href: true }),
+ * })
+ */
+export type ConditionalQuery<TResultItem, TQueryConfig extends QueryConfig> =
+  // The ConditionalQuery can be o
+  | ProjectionMap<TResultItem, TQueryConfig>
+  | IGroqBuilder<object, TQueryConfig>
+  | ((
+      sub: GroqBuilderSubquery<TResultItem, TQueryConfig>
+    ) =>
+      | ProjectionMap<TResultItem, TQueryConfig>
+      | IGroqBuilder<object, TQueryConfig>);
 
 export type ExtractConditionalProjectionResults<
   TResultItem,
@@ -37,13 +64,32 @@ export type ExtractConditionalProjectionResults<
   TConfig["key"],
   | (TConfig["isExhaustive"] extends true ? never : Empty)
   | ValueOf<{
-      [P in keyof TConditionalProjectionMap]: ExtractProjectionResult<
+      [P in keyof TConditionalProjectionMap]: ExtractConditionalQueryResult<
         TResultItem,
         TQueryConfig,
-        TConditionalProjectionMap[P]
+        NonNullable<TConditionalProjectionMap[P]>
       >;
     }>
 >;
+
+type ExtractConditionalQueryResult<
+  TResultItem,
+  TQueryConfig extends QueryConfig,
+  TConditionalQueryResult extends ConditionalQuery<TResultItem, TQueryConfig>
+> =
+  // Return the type of the GroqBuilder:
+  ReturnTypeMaybe<TConditionalQueryResult> extends IGroqBuilder<infer TResult>
+    ? TResult
+    : // Or the result of a raw projection:
+      ExtractProjectionResult<
+        TResultItem,
+        TQueryConfig,
+        ReturnTypeMaybe<TConditionalQueryResult>
+      >;
+
+type ReturnTypeMaybe<T> = T extends (...params: any) => infer TResult
+  ? TResult
+  : T;
 
 export type ExtractConditionalProjectionTypes<TProjectionMap> = Simplify<
   IntersectionOfValues<{
@@ -58,7 +104,7 @@ export type ConditionalByTypeProjectionMap<
   TResultItem,
   TQueryConfig extends QueryConfig
 > = {
-  [_type in ExtractDocumentTypes<TResultItem>]?: ProjectionMapOrCallback<
+  [_type in ExtractDocumentTypes<TResultItem>]?: ConditionalQuery<
     Extract<TResultItem, { _type: _type }>,
     TQueryConfig
   >;
@@ -93,14 +139,10 @@ export type ExtractConditionalByTypeProjectionResults<
          * this _type is automatically added to the query.
          */
         _type: _type;
-      } & ExtractProjectionResult<
+      } & ExtractConditionalQueryResult<
         Extract<TResultItem, { _type: _type }>,
         TQueryConfig,
-        TConditionalByTypeProjectionMap[_type] extends (
-          q: any
-        ) => infer TProjectionMap
-          ? TProjectionMap
-          : TConditionalByTypeProjectionMap[_type]
+        NonNullable<TConditionalByTypeProjectionMap[_type]>
       >;
     }>
 >;

--- a/packages/groqd/src/commands/subquery/conditional.test.ts
+++ b/packages/groqd/src/commands/subquery/conditional.test.ts
@@ -262,5 +262,23 @@ describe("conditional", () => {
       >;
       expectTypeOf<Result>().toEqualTypeOf<Expected>();
     });
+    it("should generate the correct query", () => {
+      expect(qAll.query).toMatchInlineSnapshot(`
+        "*[_type == "variant"] {
+            name,
+            price == msrp => {
+              "onSale": false
+            },
+            price < msrp => {
+                "onSale": true,
+                price,
+                msrp
+              }
+          }"
+      `);
+    });
+    it("should execute correctly", () => {
+      // (we actually already test this exact query in a previous test)
+    });
   });
 });

--- a/packages/groqd/src/commands/subquery/conditional.ts
+++ b/packages/groqd/src/commands/subquery/conditional.ts
@@ -1,6 +1,4 @@
-import { GroqBuilderSubquery, isGroqBuilder } from "../../groq-builder";
-import { InvalidQueryError } from "../../types/invalid-query-error";
-import { QueryConfig } from "../../types/query-config";
+import { GroqBuilderSubquery } from "../../groq-builder";
 import { ResultItem } from "../../types/result-types";
 import {
   ConditionalConfig,
@@ -8,10 +6,10 @@ import {
   ConditionalProjectionMap,
   ConditionalQuery,
   ExtractConditionalProjectionResults,
+  normalizeConditionalQuery,
 } from "./conditional-types";
-import { Empty, notNull } from "../../types/utils";
+import { notNull } from "../../types/utils";
 import { ParserFunction } from "../../types/parser-types";
-import { ProjectionMap } from "../../types/projection-types";
 
 declare module "../../groq-builder" {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -72,30 +70,7 @@ GroqBuilderSubquery.implement({
       conditionalProjections
     ).map(
       ([condition, conditionalQuery]: [string, ConditionalQuery<any, any>]) => {
-        // If it's a function, execute it:
-        if (typeof conditionalQuery === "function") {
-          conditionalQuery = conditionalQuery(subquery);
-        }
-        if (typeof conditionalQuery !== "object") {
-          throw new InvalidQueryError(
-            "INVALID_CONDITIONAL_QUERY",
-            `Expected conditionalQuery to be an object, but got a ${typeof conditionalQuery}}`,
-            { conditionalQuery }
-          );
-        }
-
-        // Handle a nested query:
-        const result = subquery.chain(`${condition} =>`);
-        if (isGroqBuilder(conditionalQuery)) {
-          return result.raw(conditionalQuery.query, conditionalQuery.parser);
-        }
-
-        // Handle a projectionMap:
-        const projectionMap = conditionalQuery as ProjectionMap<
-          Empty,
-          QueryConfig
-        >;
-        return result.project(projectionMap);
+        return normalizeConditionalQuery(subquery, condition, conditionalQuery);
       }
     );
 

--- a/packages/groqd/src/commands/subquery/conditionalByType.test.ts
+++ b/packages/groqd/src/commands/subquery/conditionalByType.test.ts
@@ -25,12 +25,22 @@ describe("conditionalByType", () => {
   const conditionalByType = getSubquery(q)
     .asType() // All types
     .conditionalByType({
-      variant: { name: true, price: true },
-      product: { name: true, slug: "slug.current" },
-      category: (qC) => ({
-        name: true,
-        slug: qC.field("slug.current"),
+      // There are 3 ways to select data:
+      // 1. Using a raw object (ProjectionMap)
+      variant: { name: true, price: "price" },
+      // 2. Using a callback that returns a ProjectionMap
+      // (because the `q` is strongly-typed)
+      product: (q) => ({
+        name: q.field("name"),
+        slug: q.field("slug.current"),
       }),
+      // 3. Using a callback that returns any query
+      // (for advanced use-cases)
+      category: (q) =>
+        q.project({
+          name: true,
+          slug: q.field("slug.current"),
+        }),
     });
 
   type ExpectedConditionalUnion =

--- a/packages/groqd/src/commands/subquery/conditionalByType.test.ts
+++ b/packages/groqd/src/commands/subquery/conditionalByType.test.ts
@@ -6,12 +6,12 @@ import {
   InferResultType,
 } from "../../groq-builder";
 import { q, SchemaConfig } from "../../tests/schemas/nextjs-sanity-fe";
-import { ExtractConditionalProjectionTypes } from "./conditional-types";
 import { executeBuilder } from "../../tests/mocks/executeQuery";
 import { mock } from "../../tests/mocks/nextjs-sanity-fe-mocks";
 import { Simplify, SimplifyDeep } from "../../types/utils";
 import { getSubquery } from "../../tests/getSubquery";
 import { ExtractDocumentTypes } from "../../types/document-types";
+import { ExtractConditionalProjectionTypes } from "./conditional-types";
 
 const data = mock.generateSeedData({
   products: mock.array(5, (i) =>
@@ -28,7 +28,7 @@ describe("conditionalByType", () => {
       // There are 3 ways to select data:
       // 1. Using a raw object (ProjectionMap)
       variant: { name: true, price: "price" },
-      // 2. Using a callback that returns a ProjectionMap
+      // 2. Using a callback that returns an object (ProjectionMap)
       // (because the `q` is strongly-typed)
       product: (q) => ({
         name: q.field("name"),

--- a/packages/groqd/src/commands/subquery/conditionalByType.ts
+++ b/packages/groqd/src/commands/subquery/conditionalByType.ts
@@ -1,13 +1,13 @@
 import { GroqBuilderSubquery } from "../../groq-builder";
-import { QueryConfig } from "../../types/query-config";
 import { ResultItem } from "../../types/result-types";
 import {
   ExtractConditionalByTypeProjectionResults,
   ConditionalByTypeProjectionMap,
   ConditionalKey,
   ConditionalConfig,
+  ConditionalQuery,
+  normalizeConditionalQuery,
 } from "./conditional-types";
-import { ProjectionMap } from "../../types/projection-types";
 import { keys } from "../../types/utils";
 import { ExtractDocumentTypes } from "../../types/document-types";
 
@@ -73,14 +73,15 @@ GroqBuilderSubquery.implement({
 
     const subquery = this.subquery;
     const conditions = typeNames.map((_type) => {
-      const projectionMap = conditionalProjections[_type] as ProjectionMap<
-        unknown,
-        QueryConfig
-      >;
-      const conditionQuery = subquery
-        .chain(`_type == "${_type}" =>`)
-        .project(projectionMap);
-      const { query, parser } = conditionQuery;
+      const condition = `_type == "${_type}"`;
+      const conditionalQuery = conditionalProjections[
+        _type
+      ] as ConditionalQuery<any, any>;
+      const { query, parser } = normalizeConditionalQuery(
+        subquery,
+        condition,
+        conditionalQuery
+      );
       return { _type, query, parser };
     });
 

--- a/packages/groqd/src/groq-builder/index.test.ts
+++ b/packages/groqd/src/groq-builder/index.test.ts
@@ -46,6 +46,8 @@ describe("GroqBuilderSubquery", () => {
       | "asType"
       | "asCombined"
       | "raw"
+      | "star"
+      | "value"
       // Subquery utils:
       | "count"
       | "coalesce"

--- a/packages/groqd/src/types/projection-types.ts
+++ b/packages/groqd/src/types/projection-types.ts
@@ -1,4 +1,3 @@
-import { GroqBuilderSubquery } from "../groq-builder";
 import { Expressions } from "./groq-expressions";
 import {
   Empty,
@@ -30,15 +29,6 @@ export type ProjectionMap<TResultItem, TQueryConfig extends QueryConfig> = {
   // Obviously this allows the ellipsis operator:
   "..."?: true | Parser;
 };
-
-export type ProjectionMapOrCallback<
-  TResultItem,
-  TQueryConfig extends QueryConfig
-> =
-  | ProjectionMap<TResultItem, TQueryConfig>
-  | ((
-      sub: GroqBuilderSubquery<TResultItem, TQueryConfig>
-    ) => ProjectionMap<TResultItem, TQueryConfig>);
 
 export type ProjectionFieldConfig<
   TResultItem,


### PR DESCRIPTION
# Conditionals now support a "query"

Within a conditional, you normally use a projection. 
However, in some scenarios, you can use a more complex query.
This PR adds support to use queries within a conditional.

There are certain edge-cases that this helps support:
```ts
q.star.filterByType("test").project(q => ({
  link: q.field("link").project(q => ({
    // ☝️ in this example, a "link" can be either an inline "link" object, or a reference to a "link"
    ...q.conditionalByType({
      link: { url: true }, // 👈 Current syntax is used for simple projections
      reference: q => q.field("@").deref().project({ url: true }), // 🆕 Now you can use a more complex query like this
    }),
  })),
}));
```

# Additional Improvements

Promoted these root methods to be available in a subquery.  
- sub.value(...)
- sub.star...

This allows us to "shadow" the `q` variable when writing projections, like:
```ts
q.star.filterByType("product").project((q) => ({ // 👈 We're intentionally shadowing the top-level `q` object
  name: q.field("name"), // 👈 `q` is strongly-typed
  // 🆕 We can still use `q.value(...)`, even though we shadowed `q`:
  truthy: q.value(true), 
  // 🆕 We can now use `q.star` and it understands the context-specific `"references(^._id)"`
  categories: q.star.filterByType("category").filterBy("references(^._id)"), 
}));
```