### PR TITLE
Feature: not equal expressions (`!=`)

### DIFF
--- a/.changeset/late-seas-dream.md
+++ b/.changeset/late-seas-dream.md
@@ -1,0 +1,7 @@
+---
+"groqd": minor
+---
+
+Feature: 
+- Added support for "not equal" expressions (`!=`).
+- This applies to the `.filterBy` and `.conditional` methods

--- a/packages/groqd/src/commands/filter.test.ts
+++ b/packages/groqd/src/commands/filter.test.ts
@@ -116,7 +116,7 @@ describe("filterBy", () => {
         name: z.string(),
         price: z.number(),
       })
-      .filterBy("price == 99");
+      .filterBy("price > 99");
     expectTypeOf<InferResultItem<typeof query>>().toEqualTypeOf<{
       name: string;
       price: number;
@@ -125,7 +125,7 @@ describe("filterBy", () => {
       "*[_type == "variant"] {
           name,
           price
-        }[price == 99]"
+        }[price > 99]"
     `);
     expect(query.parser).toBeDefined();
   });
@@ -138,12 +138,16 @@ describe("filterBy", () => {
     const qWithVars = qVariants.parameters<Parameters>();
     it("should support strongly-typed parameters", () => {
       qWithVars.filterBy("name == $str");
-      qWithVars.filterBy("price == $num");
+      qWithVars.filterBy("price <= $num");
     });
     it("should fail for invalid / mismatched parameters", () => {
       qWithVars.filterBy(
         // @ts-expect-error ---
         "name == $num"
+      );
+      qWithVars.filterBy(
+        // @ts-expect-error ---
+        "name > $num"
       );
       qWithVars.filterBy(
         // @ts-expect-error ---

--- a/packages/groqd/src/types/groq-expressions.test.ts
+++ b/packages/groqd/src/types/groq-expressions.test.ts
@@ -502,16 +502,13 @@ describe("Expressions.Score", () => {
   type StandardConditionals = Expressions.Conditional<FooBarBaz, QueryConfig>;
   type ScoreSuggestions = Expressions.Score<FooBarBaz, QueryConfig>;
   it('should include "match" with suggestions', () => {
-    type ExpectedSuggestions =
+    type Actual = Exclude<ScoreSuggestions, StandardConditionals>;
+    type Expected =
       // Only string-fields (e.g. "foo") should be suggested with "match"
       `foo match "${string}"` | "foo match (string)";
 
-    type ActualSuggestions = Exclude<ScoreSuggestions, StandardConditionals>;
-    expectTypeOf<ActualSuggestions>().toEqualTypeOf<ExpectedSuggestions>();
-    type Missing = Exclude<ExpectedSuggestions, ActualSuggestions>;
-    expectTypeOf<Missing>().toEqualTypeOf<never>();
-    type Extra = Exclude<ActualSuggestions, ExpectedSuggestions>;
-    expectTypeOf<Extra>().toEqualTypeOf<never>();
+    expectTypeOf<Exclude<Expected, Actual>>().toEqualTypeOf<never>();
+    expectTypeOf<Exclude<Actual, Expected>>().toEqualTypeOf<never>();
   });
 });
 describe("Expressions.Order", () => {

--- a/packages/groqd/src/types/groq-expressions.test.ts
+++ b/packages/groqd/src/types/groq-expressions.test.ts
@@ -20,13 +20,21 @@ type WithParameters<TVars> = QueryConfig & {
 };
 describe("Expressions.Conditional (simple)", () => {
   type eq = "==" | "!=";
+  type gte = ">=" | ">" | "<" | "<=" | eq;
   it("literal values are properly escaped", () => {
     expectTypeOf<
       Expressions.Conditional<{ foo: "FOO" }, QueryConfig>
     >().toEqualTypeOf<'foo == "FOO"' | 'foo != "FOO"'>();
     expectTypeOf<
       Expressions.Conditional<{ foo: 999 }, QueryConfig>
-    >().toEqualTypeOf<"foo == 999" | "foo != 999">();
+    >().toEqualTypeOf<
+      | "foo == 999"
+      | "foo != 999"
+      | "foo >= 999"
+      | "foo > 999"
+      | "foo < 999"
+      | "foo <= 999"
+    >();
     expectTypeOf<
       Expressions.Conditional<{ foo: true }, QueryConfig>
     >().toEqualTypeOf<"foo" | "!foo">();
@@ -40,7 +48,7 @@ describe("Expressions.Conditional (simple)", () => {
     >().toEqualTypeOf<`foo ${eq} "${string}"` | `foo ${eq} (string)`>();
     expectTypeOf<
       Expressions.Conditional<{ foo: number }, QueryConfig>
-    >().toEqualTypeOf<`foo ${eq} ${number}` | `foo ${eq} (number)`>();
+    >().toEqualTypeOf<`foo ${gte} ${number}` | `foo ${gte} (number)`>();
     expectTypeOf<
       Expressions.Conditional<{ foo: boolean }, QueryConfig>
     >().toEqualTypeOf<"foo" | "!foo">();
@@ -62,7 +70,7 @@ describe("Expressions.Conditional (simple)", () => {
   it("multiple literals", () => {
     expectTypeOf<
       Expressions.Conditional<{ foo: "FOO"; bar: 999 }, QueryConfig>
-    >().toEqualTypeOf<`foo ${eq} "FOO"` | `bar ${eq} 999`>();
+    >().toEqualTypeOf<`foo ${eq} "FOO"` | `bar ${gte} 999`>();
   });
   it("multiple primitives", () => {
     expectTypeOf<
@@ -70,15 +78,15 @@ describe("Expressions.Conditional (simple)", () => {
     >().toEqualTypeOf<
       | `foo ${eq} (string)`
       | `foo ${eq} "${string}"`
-      | `bar ${eq} (number)`
-      | `bar ${eq} ${number}`
+      | `bar ${gte} (number)`
+      | `bar ${gte} ${number}`
     >();
   });
   it("mixed types", () => {
     expectTypeOf<
       Expressions.Conditional<{ foo: "FOO"; bar: number }, QueryConfig>
     >().toEqualTypeOf<
-      `foo ${eq} "FOO"` | `bar ${eq} (number)` | `bar ${eq} ${number}`
+      `foo ${eq} "FOO"` | `bar ${gte} (number)` | `bar ${gte} ${number}`
     >();
   });
 
@@ -103,18 +111,18 @@ describe("Expressions.Conditional (simple)", () => {
           WithParameters<{ str: string }>
         >
       >().toEqualTypeOf<
-        `bar ${eq} ${number}` | `bar ${eq} (number)` | "references($str)"
+        `bar ${gte} ${number}` | `bar ${gte} (number)` | "references($str)"
       >();
       expectTypeOf<
         Expressions.Conditional<{ foo: 999 }, WithParameters<{ num: number }>>
-      >().toEqualTypeOf<`foo ${eq} 999` | `foo ${eq} $num`>();
+      >().toEqualTypeOf<`foo ${gte} 999` | `foo ${gte} $num`>();
       expectTypeOf<
         Expressions.Conditional<
           { foo: number },
           WithParameters<{ num: number }>
         >
       >().toEqualTypeOf<
-        `foo ${eq} $num` | `foo ${eq} (number)` | `foo ${eq} ${number}`
+        `foo ${gte} $num` | `foo ${gte} (number)` | `foo ${gte} ${number}`
       >();
     });
 
@@ -139,9 +147,9 @@ describe("Expressions.Conditional (simple)", () => {
         | `bar.str ${eq} $str`
         | `bar.str ${eq} (string)`
         | `bar.str ${eq} "${string}"`
-        | `bar.num ${eq} $num`
-        | `bar.num ${eq} (number)`
-        | `bar.num ${eq} ${number}`
+        | `bar.num ${gte} $num`
+        | `bar.num ${gte} (number)`
+        | `bar.num ${gte} ${number}`
         | "references($str)";
 
       expectTypeOf<Exclude<Expected, Actual>>().toEqualTypeOf<never>();

--- a/packages/groqd/src/types/groq-expressions.test.ts
+++ b/packages/groqd/src/types/groq-expressions.test.ts
@@ -1,12 +1,13 @@
 import { describe, expectTypeOf, it } from "vitest";
+import { SanitySchema } from "../tests/schemas/nextjs-sanity-fe";
 import { Expressions } from "./groq-expressions";
+import { ParametersWith$Sign } from "./parameter-types";
+import { ProjectionPathEntries } from "./projection-paths";
 import {
   ConfigAddParameters,
   ConfigCreateNestedScope,
   QueryConfig,
 } from "./query-config";
-import { ParametersWith$Sign } from "./parameter-types";
-import { SanitySchema } from "../tests/schemas/nextjs-sanity-fe";
 
 type FooBarBaz = {
   foo: string;
@@ -17,88 +18,103 @@ type FooBarBaz = {
 type WithParameters<TVars> = QueryConfig & {
   scope: ParametersWith$Sign<TVars>;
 };
-
-describe("Expressions.Equality", () => {
+describe("Expressions.Conditional (simple)", () => {
+  type eq = "==" | "!=";
   it("literal values are properly escaped", () => {
     expectTypeOf<
-      Expressions.Equality<{ foo: "FOO" }, QueryConfig>
-    >().toEqualTypeOf<'foo == "FOO"'>();
+      Expressions.Conditional<{ foo: "FOO" }, QueryConfig>
+    >().toEqualTypeOf<'foo == "FOO"' | 'foo != "FOO"'>();
     expectTypeOf<
-      Expressions.Equality<{ foo: 999 }, QueryConfig>
-    >().toEqualTypeOf<"foo == 999">();
+      Expressions.Conditional<{ foo: 999 }, QueryConfig>
+    >().toEqualTypeOf<"foo == 999" | "foo != 999">();
     expectTypeOf<
-      Expressions.Equality<{ foo: true }, QueryConfig>
-    >().toEqualTypeOf<never>();
+      Expressions.Conditional<{ foo: true }, QueryConfig>
+    >().toEqualTypeOf<"foo" | "!foo">();
     expectTypeOf<
-      Expressions.Equality<{ foo: null }, QueryConfig>
-    >().toEqualTypeOf<"foo == null">();
+      Expressions.Conditional<{ foo: null }, QueryConfig>
+    >().toEqualTypeOf<"foo == null" | "foo != null">();
   });
   it("primitive values are properly typed", () => {
     expectTypeOf<
-      Expressions.Equality<{ foo: string }, QueryConfig>
-    >().toEqualTypeOf<`foo == "${string}"` | "foo == (string)">();
+      Expressions.Conditional<{ foo: string }, QueryConfig>
+    >().toEqualTypeOf<`foo ${eq} "${string}"` | `foo ${eq} (string)`>();
     expectTypeOf<
-      Expressions.Equality<{ foo: number }, QueryConfig>
-    >().toEqualTypeOf<`foo == ${number}` | "foo == (number)">();
+      Expressions.Conditional<{ foo: number }, QueryConfig>
+    >().toEqualTypeOf<`foo ${eq} ${number}` | `foo ${eq} (number)`>();
     expectTypeOf<
-      Expressions.Equality<{ foo: boolean }, QueryConfig>
-    >().toEqualTypeOf<never>();
+      Expressions.Conditional<{ foo: boolean }, QueryConfig>
+    >().toEqualTypeOf<"foo" | "!foo">();
     expectTypeOf<
-      Expressions.Equality<{ foo: null }, QueryConfig>
-    >().toEqualTypeOf<`foo == null`>();
+      Expressions.Conditional<{ foo: null }, QueryConfig>
+    >().toEqualTypeOf<`foo ${eq} null`>();
   });
   it("optional values are properly typed", () => {
     expectTypeOf<
-      Expressions.Equality<{ foo: undefined }, QueryConfig>
-    >().toEqualTypeOf<"foo == null">();
+      Expressions.Conditional<{ foo: undefined }, QueryConfig>
+    >().toEqualTypeOf<`foo ${eq} null`>();
     expectTypeOf<
-      Expressions.Equality<{ foo?: 999 }, QueryConfig>
-    >().toEqualTypeOf<"foo == null" | "foo == 999" | "foo == (number)">();
+      Expressions.Conditional<{ foo?: 999 }, QueryConfig>
+    >().toEqualTypeOf<
+      `foo ${eq} null` | `foo ${eq} 999` | `foo ${eq} (number)`
+    >();
   });
 
   it("multiple literals", () => {
     expectTypeOf<
-      Expressions.Equality<{ foo: "FOO"; bar: 999 }, QueryConfig>
-    >().toEqualTypeOf<'foo == "FOO"' | "bar == 999">();
+      Expressions.Conditional<{ foo: "FOO"; bar: 999 }, QueryConfig>
+    >().toEqualTypeOf<`foo ${eq} "FOO"` | `bar ${eq} 999`>();
   });
   it("multiple primitives", () => {
     expectTypeOf<
-      Expressions.Equality<{ foo: string; bar: number }, QueryConfig>
+      Expressions.Conditional<{ foo: string; bar: number }, QueryConfig>
     >().toEqualTypeOf<
-      | "foo == (string)"
-      | `foo == "${string}"`
-      | "bar == (number)"
-      | `bar == ${number}`
+      | `foo ${eq} (string)`
+      | `foo ${eq} "${string}"`
+      | `bar ${eq} (number)`
+      | `bar ${eq} ${number}`
     >();
   });
   it("mixed types", () => {
     expectTypeOf<
-      Expressions.Equality<{ foo: "FOO"; bar: number }, QueryConfig>
+      Expressions.Conditional<{ foo: "FOO"; bar: number }, QueryConfig>
     >().toEqualTypeOf<
-      'foo == "FOO"' | "bar == (number)" | `bar == ${number}`
+      `foo ${eq} "FOO"` | `bar ${eq} (number)` | `bar ${eq} ${number}`
     >();
   });
 
   describe("with parameters", () => {
     it("a literal value can be compared to parameters with the same type", () => {
       expectTypeOf<
-        Expressions.Equality<{ foo: "FOO" }, WithParameters<{ str: string }>>
-      >().toEqualTypeOf<'foo == "FOO"' | "foo == $str">();
-      expectTypeOf<
-        Expressions.Equality<{ foo: string }, WithParameters<{ str: "FOO" }>>
+        Expressions.Conditional<{ foo: "FOO" }, WithParameters<{ str: string }>>
       >().toEqualTypeOf<
-        `foo == "${string}"` | "foo == (string)" | "foo == $str"
+        `foo ${eq} "FOO"` | `foo ${eq} $str` | "references($str)"
       >();
       expectTypeOf<
-        Expressions.Equality<{ bar: number }, WithParameters<{ str: string }>>
-      >().toEqualTypeOf<`bar == ${number}` | "bar == (number)">();
-      expectTypeOf<
-        Expressions.Equality<{ foo: 999 }, WithParameters<{ num: number }>>
-      >().toEqualTypeOf<`foo == 999` | "foo == $num">();
-      expectTypeOf<
-        Expressions.Equality<{ foo: number }, WithParameters<{ num: number }>>
+        Expressions.Conditional<{ foo: string }, WithParameters<{ str: "FOO" }>>
       >().toEqualTypeOf<
-        "foo == $num" | "foo == (number)" | `foo == ${number}`
+        | `foo ${eq} "${string}"`
+        | `foo ${eq} (string)`
+        | `foo ${eq} $str`
+        | "references($str)"
+      >();
+      expectTypeOf<
+        Expressions.Conditional<
+          { bar: number },
+          WithParameters<{ str: string }>
+        >
+      >().toEqualTypeOf<
+        `bar ${eq} ${number}` | `bar ${eq} (number)` | "references($str)"
+      >();
+      expectTypeOf<
+        Expressions.Conditional<{ foo: 999 }, WithParameters<{ num: number }>>
+      >().toEqualTypeOf<`foo ${eq} 999` | `foo ${eq} $num`>();
+      expectTypeOf<
+        Expressions.Conditional<
+          { foo: number },
+          WithParameters<{ num: number }>
+        >
+      >().toEqualTypeOf<
+        `foo ${eq} $num` | `foo ${eq} (number)` | `foo ${eq} ${number}`
       >();
     });
 
@@ -111,29 +127,25 @@ describe("Expressions.Equality", () => {
           num: number;
         };
       };
-      type Actual = Expressions.Equality<
-        WithNested,
+      type Actual = Expressions.Conditional<
+        ProjectionPathEntries<WithNested>,
         WithParameters<{ str: string; num: number }>
       >;
       type Expected =
-        | "foo == $str"
-        | 'foo == "FOO"'
-        | 'bar.baz == "BAZ"'
-        | "bar.baz == $str"
-        | "bar.str == $str"
-        | "bar.str == (string)"
-        | `bar.str == "${string}"`
-        | "bar.num == $num"
-        | "bar.num == (number)"
-        | `bar.num == ${number}`;
+        | `foo ${eq} $str`
+        | `foo ${eq} "FOO"`
+        | `bar.baz ${eq} "BAZ"`
+        | `bar.baz ${eq} $str`
+        | `bar.str ${eq} $str`
+        | `bar.str ${eq} (string)`
+        | `bar.str ${eq} "${string}"`
+        | `bar.num ${eq} $num`
+        | `bar.num ${eq} (number)`
+        | `bar.num ${eq} ${number}`
+        | "references($str)";
 
-      // This is really hard to debug:
-      expectTypeOf<Actual>().toEqualTypeOf<Expected>();
-      // Here are 2 easier ways to debug:
-      type ActualExtras = Exclude<Expected, Actual>;
-      type ActualMissing = Exclude<Actual, Expected>;
-      expectTypeOf<ActualExtras>().toEqualTypeOf<never>();
-      expectTypeOf<ActualMissing>().toEqualTypeOf<never>();
+      expectTypeOf<Exclude<Expected, Actual>>().toEqualTypeOf<never>();
+      expectTypeOf<Exclude<Actual, Expected>>().toEqualTypeOf<never>();
     });
 
     type ManyParameters = {
@@ -161,20 +173,24 @@ describe("Expressions.Equality", () => {
     });
 
     it("multiple values are compared to same-typed parameters", () => {
-      type Res = Expressions.Equality<
+      type Res = Expressions.Conditional<
         FooBarBaz,
         WithParameters<ManyParameters>
       >;
       type Expected =
-        | "foo == $str1"
-        | "foo == $str2"
-        | "foo == (string)"
-        | `foo == "${string}"`
-        | "bar == $num1"
-        | "bar == (number)"
-        | `bar == ${number}`
-        | `bar == null`
-        | "baz == $bool";
+        | `foo ${eq} $str1`
+        | `foo ${eq} $str2`
+        | `foo ${eq} (string)`
+        | `foo ${eq} "${string}"`
+        | `bar ${eq} $num1`
+        | `bar ${eq} (number)`
+        | `bar ${eq} ${number}`
+        | `bar ${eq} null`
+        | `baz ${eq} $bool`
+        | "baz"
+        | "!baz"
+        | "references($str1)"
+        | "references($str2)";
 
       expectTypeOf<Exclude<Res, Expected>>().toEqualTypeOf<never>();
       expectTypeOf<Exclude<Expected, Res>>().toEqualTypeOf<never>();
@@ -190,24 +206,34 @@ describe("Expressions.Equality", () => {
       };
     };
     it("should work with deeply-nested parameters", () => {
-      type Res = Expressions.Equality<
+      type Res = Expressions.Conditional<
         FooBarBaz,
         WithParameters<NestedParameters>
       >;
 
       type StandardSuggestions =
-        | "foo == (string)"
-        | `foo == "${string}"`
-        | `bar == (number)`
-        | `bar == ${number}`
-        | `bar == null`
-        | `baz == ${boolean}`;
+        | `foo ${eq} (string)`
+        | `foo ${eq} "${string}"`
+        | `bar ${eq} (number)`
+        | `bar ${eq} ${number}`
+        | `bar ${eq} null`
+        | `baz ${eq} ${boolean}`;
       type NestedSuggestions = Exclude<Res, StandardSuggestions>;
-      expectTypeOf<NestedSuggestions>().toEqualTypeOf<
-        | "foo == $nested.str1"
-        | "foo == $nested.deep.str2"
-        | "bar == $nested.deep.num1"
-      >();
+      type Expected =
+        | `foo ${eq} $nested.str1`
+        | `foo ${eq} $nested.deep.str2`
+        | `bar ${eq} $nested.deep.num1`
+        | "baz"
+        | "!baz"
+        | "references($nested.str1)"
+        | "references($nested.deep.str2)";
+
+      expectTypeOf<
+        Exclude<Expected, NestedSuggestions>
+      >().toEqualTypeOf<never>();
+      expectTypeOf<
+        Exclude<NestedSuggestions, Expected>
+      >().toEqualTypeOf<never>();
     });
   });
 });

--- a/packages/groqd/src/types/groq-expressions.ts
+++ b/packages/groqd/src/types/groq-expressions.ts
@@ -102,8 +102,15 @@ export namespace Expressions {
 
   export type Inequality<
     TResultItem,
-    _TQueryConfig extends QueryConfig
-  > = `${ProjectionPathsByType<TResultItem, null>} != null`;
+    TQueryConfig extends QueryConfig
+  > = Comparison<
+    ConditionalPick<
+      ProjectionPathEntries<TResultItem>,
+      string | number | boolean | null
+    >,
+    TQueryConfig,
+    "!="
+  >;
 
   export type MatchExpression<
     TResultItem,
@@ -134,7 +141,7 @@ export namespace Expressions {
    */
   type LiteralValue<TValue> = TValue extends string
     ? `"${TValue}"`
-    : TValue extends number | boolean | null
+    : TValue extends number | null
     ? TValue
     : TValue extends undefined
     ? null

--- a/packages/groqd/src/types/groq-expressions.ts
+++ b/packages/groqd/src/types/groq-expressions.ts
@@ -112,9 +112,13 @@ export namespace Expressions {
   >;
 
   type MatchExpression<
-    TPathEntries,
+    TResultItem,
     TQueryConfig extends QueryConfig
-  > = Comparison<ConditionalPick<TPathEntries, string>, TQueryConfig, "match">;
+  > = Comparison<
+    ConditionalPick<ProjectionPathEntries<TResultItem>, string>,
+    TQueryConfig,
+    "match"
+  >;
 
   type References<TQueryConfig extends QueryConfig> = `references(${IgnorePaths<
     ProjectionPathsByType<ConfigGetScope<TQueryConfig>, string | string[]>,

--- a/packages/groqd/src/types/groq-expressions.ts
+++ b/packages/groqd/src/types/groq-expressions.ts
@@ -72,7 +72,7 @@ export namespace Expressions {
 
   /**
    * A strongly-typed conditional Groq conditional expression.
-   * Currently, this only supports simple "equality" expressions,
+   * Currently, this only supports various simple expressions,
    * like '_type == "product"' or 'slug.current == $slug'.
    * */
   export type Conditional<
@@ -82,6 +82,7 @@ export namespace Expressions {
     ? // Currently we only support these simple expressions:
       | Equality<$PathEntries, TQueryConfig>
         | Inequality<$PathEntries, TQueryConfig>
+        | NumberComparisons<$PathEntries, TQueryConfig>
         | BooleanSuggestions<$PathEntries>
         | References<TQueryConfig>
     : never;

--- a/packages/groqd/src/types/utils.ts
+++ b/packages/groqd/src/types/utils.ts
@@ -142,3 +142,16 @@ export type JustOneOf<TUnion> = UnionToIntersection<
 > extends () => infer R
   ? R
   : never;
+
+/**
+ * TSGenerics doesn't provide a way to create variables.
+ * This utility adds a way to create a variable.
+ * @example
+ * type Example<T> =
+ *   // Create a variable using this "extends infer" approach:
+ *   Variable<{ foo: T, bar: T, baz: T }> extends infer FooBarBaz
+ *   // Now you can use the FooBarBaz variable:
+ *   ? FooBarBaz
+ *   : never;
+ */
+export type Variable<T> = T;


### PR DESCRIPTION
- Adds support for "not equal" conditional expressions
- This applies to the `filterBy(...)` method and the `conditional(...)` method

Examples:
`filterBy`
<img width="619" alt="image" src="https://github.com/user-attachments/assets/f6bceea2-e50a-4bf5-bc1e-9d025d25a7c2" />


`conditional`
<img width="698" alt="image" src="https://github.com/user-attachments/assets/582969f2-e4a0-4da0-be88-a85b0a23cc13" />
