### PR TITLE
Feature: simplify Fragments

### DIFF
--- a/.changeset/kind-lies-act.md
+++ b/.changeset/kind-lies-act.md
@@ -1,0 +1,5 @@
+---
+"groqd": minor
+---
+
+Fix: simplify Fragments types to eliminate `"Type instantiation is excessively deep and possibly infinite."` errors

--- a/.changeset/nine-balloons-add.md
+++ b/.changeset/nine-balloons-add.md
@@ -1,0 +1,5 @@
+---
+"groqd": patch
+---
+
+Feature: reduce dependency on Zod to ensure wider compatibility between Zod versions

--- a/packages/groqd/src/commands/root/fragment.ts
+++ b/packages/groqd/src/commands/root/fragment.ts
@@ -6,7 +6,6 @@ import {
 import { QueryConfig } from "../../types/query-config";
 import { RequireAFakeParameterIfThereAreTypeMismatchErrors } from "../../types/type-mismatch-error";
 import { ExtractDocumentTypes } from "../../types/document-types";
-import { Simplify } from "type-fest";
 import { Fragment } from "../../types/fragment-types";
 
 declare module "../../groq-builder" {
@@ -72,7 +71,7 @@ export type FragmentUtil<TQueryConfig extends QueryConfig, TFragmentInput> = {
           sub: GroqBuilderSubquery<TFragmentInput, TQueryConfig>
         ) => TProjectionMap),
     ...__projectionMapTypeMismatchErrors: RequireAFakeParameterIfThereAreTypeMismatchErrors<_TProjectionResult>
-  ): Fragment<Simplify<_TProjectionResult>, TFragmentInput, TProjectionMap>;
+  ): Fragment<TFragmentInput, TQueryConfig, TProjectionMap>;
 };
 
 GroqBuilderRoot.implement({

--- a/packages/groqd/src/commands/subquery/conditional.test.ts
+++ b/packages/groqd/src/commands/subquery/conditional.test.ts
@@ -431,5 +431,34 @@ describe("conditional", () => {
         `);
       });
     });
+    describe("when multiple conditions can be true", () => {
+      const qConditional = qVariants.project((q) => ({
+        name: z.string(),
+        ...q.conditional({
+          "price < msrp": {
+            price: z.number(),
+          },
+          "price <= msrp": {
+            msrp: z.number(),
+          },
+        }),
+      }));
+      it("should include fields from both conditions", async () => {
+        const results = await executeBuilder(qConditional, data);
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "msrp": 10,
+              "name": "Variant 1",
+            },
+            {
+              "msrp": 9,
+              "name": "Variant 2",
+              "price": 8,
+            },
+          ]
+        `);
+      });
+    });
   });
 });

--- a/packages/groqd/src/commands/subquery/conditional.test.ts
+++ b/packages/groqd/src/commands/subquery/conditional.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, expectTypeOf, it } from "vitest";
+import { z } from "zod";
 import { GroqBuilderBase, InferResultItem, InferResultType } from "../../index";
+import { executeBuilder } from "../../tests/mocks/executeQuery";
+import { mock } from "../../tests/mocks/nextjs-sanity-fe-mocks";
 import { q } from "../../tests/schemas/nextjs-sanity-fe";
 import { ExtractConditionalProjectionTypes } from "./conditional-types";
 import { Empty, Simplify } from "../../types/utils";
@@ -37,7 +40,7 @@ describe("conditional", () => {
     });
   });
 
-  const qAll = qVariants.project((qV) => ({
+  const qConditional = qVariants.project((qV) => ({
     name: true,
     ...qV.conditional({
       "price == msrp": {
@@ -50,9 +53,8 @@ describe("conditional", () => {
       },
     }),
   }));
-
   it("should be able to extract the return type", () => {
-    expectTypeOf<InferResultType<typeof qAll>>().toEqualTypeOf<
+    expectTypeOf<InferResultType<typeof qConditional>>().toEqualTypeOf<
       Array<
         | { name: string }
         | { name: string; onSale: false }
@@ -60,9 +62,8 @@ describe("conditional", () => {
       >
     >();
   });
-
   it("the query should look correct", () => {
-    expect(qAll.query).toMatchInlineSnapshot(
+    expect(qConditional.query).toMatchInlineSnapshot(
       `
       "*[_type == "variant"] {
           name,
@@ -238,47 +239,197 @@ describe("conditional", () => {
     });
   });
 
+  const data = mock.generateSeedData({
+    variants: [
+      //
+      mock.variant({
+        name: "Variant 1",
+        price: 10,
+        msrp: 10,
+      }),
+      mock.variant({ name: "Variant 2", price: 8, msrp: 9 }),
+    ],
+  });
   describe("using query syntax", () => {
-    const qAll = qVariants.project((q) => ({
+    const qConditional = qVariants.project((q) => ({
       name: true,
       ...q.conditional({
         "price == msrp": q.project({
           onSale: q.value(false),
+          msrp: true,
         }),
         "price < msrp": (q) =>
           q.project({
             onSale: q.value(true),
             price: true,
-            msrp: true,
           }),
       }),
     }));
     it("should have the correct expected type", () => {
-      type Result = InferResultType<typeof qAll>;
+      type Result = InferResultType<typeof qConditional>;
       type Expected = Array<
         | { name: string }
-        | { name: string; onSale: false }
-        | { name: string; onSale: true; price: number; msrp: number }
+        | { name: string; onSale: false; msrp: number }
+        | { name: string; onSale: true; price: number }
       >;
       expectTypeOf<Result>().toEqualTypeOf<Expected>();
     });
     it("should generate the correct query", () => {
-      expect(qAll.query).toMatchInlineSnapshot(`
+      expect(qConditional.query).toMatchInlineSnapshot(`
         "*[_type == "variant"] {
             name,
             price == msrp => {
-              "onSale": false
+              "onSale": false,
+              msrp
             },
             price < msrp => {
                 "onSale": true,
-                price,
-                msrp
+                price
               }
           }"
       `);
     });
-    it("should execute correctly", () => {
-      // (we actually already test this exact query in a previous test)
+    it("should execute correctly", async () => {
+      const results = await executeBuilder(qConditional, data);
+      expect(results).toMatchInlineSnapshot(`
+        [
+          {
+            "msrp": 10,
+            "name": "Variant 1",
+            "onSale": false,
+          },
+          {
+            "name": "Variant 2",
+            "onSale": true,
+            "price": 8,
+          },
+        ]
+      `);
+    });
+  });
+
+  describe("with validation", () => {
+    const qConditional = qVariants.project((q) => ({
+      name: z.string(),
+      ...q.conditional({
+        "price == msrp": {
+          onSale: q.value(false, z.literal(false)),
+          msrp: z.number(),
+        },
+        "price < msrp": {
+          onSale: q.value(true, z.literal(true)),
+          price: z.number(),
+        },
+      }),
+    }));
+    it("should have the correct expected type", () => {
+      type Result = InferResultType<typeof qConditional>;
+      type Expected = Array<
+        | { name: string }
+        | { name: string; onSale: false; msrp: number }
+        | { name: string; onSale: true; price: number }
+      >;
+      expectTypeOf<Result>().toEqualTypeOf<Expected>();
+    });
+    it("should generate the correct query", () => {
+      expect(qConditional.query).toMatchInlineSnapshot(`
+        "*[_type == "variant"] {
+            name,
+            price == msrp => {
+                "onSale": false,
+                msrp
+              },
+            price < msrp => {
+                "onSale": true,
+                price
+              }
+          }"
+      `);
+    });
+    it("should execute correctly", async () => {
+      const results = await executeBuilder(qConditional, data);
+      expect(results).toMatchInlineSnapshot(`
+        [
+          {
+            "msrp": 10,
+            "name": "Variant 1",
+            "onSale": false,
+          },
+          {
+            "name": "Variant 2",
+            "onSale": true,
+            "price": 8,
+          },
+        ]
+      `);
+    });
+
+    const invalidData = mock.generateSeedData({
+      variants: [
+        mock.variant({ name: "Variant 1 (valid)", price: 10, msrp: 10 }),
+        mock.variant({ name: "Variant 2 (valid)", price: 9, msrp: 10 }),
+        mock.variant({ name: "Variant 3 (invalid)", price: 11, msrp: 10 }),
+        // @ts-expect-error -- must be numbers
+        mock.variant({ name: "Variant 4 (invalid)", price: "10", msrp: "10" }),
+        // @ts-expect-error -- must be numbers
+        mock.variant({ name: "Variant 5 (invalid)", price: "8", msrp: "9" }),
+      ],
+    });
+    describe("when the data is invalid", () => {
+      it("should strip invalid fields", async () => {
+        const result = await executeBuilder(qConditional, invalidData);
+        expect(result).toMatchInlineSnapshot(`
+          [
+            {
+              "msrp": 10,
+              "name": "Variant 1 (valid)",
+              "onSale": false,
+            },
+            {
+              "name": "Variant 2 (valid)",
+              "onSale": true,
+              "price": 9,
+            },
+            {
+              "name": "Variant 3 (invalid)",
+            },
+            {
+              "name": "Variant 4 (invalid)",
+            },
+            {
+              "name": "Variant 5 (invalid)",
+            },
+          ]
+        `);
+      });
+    });
+    describe("when the isExhaustive flag is set", () => {
+      const qConditional = qVariants.project((q) => ({
+        name: z.string(),
+        ...q.conditional(
+          {
+            "price == msrp": {
+              onSale: q.value(false, z.literal(false)),
+              msrp: z.number(),
+            },
+            "price < msrp": {
+              onSale: q.value(true, z.literal(true)),
+              price: z.number(),
+            },
+          },
+          { isExhaustive: true }
+        ),
+      }));
+      it("should throw an error", async () => {
+        await expect(async () => {
+          return await executeBuilder(qConditional, invalidData);
+        }).rejects.toThrowErrorMatchingInlineSnapshot(`
+          [ValidationErrors: 3 Parsing Errors:
+          result[2]: The data did not match any of the 2 conditional assertions
+          result[3]: The data did not match any of the 2 conditional assertions
+          result[4]: The data did not match any of the 2 conditional assertions]
+        `);
+      });
     });
   });
 });

--- a/packages/groqd/src/commands/subquery/conditional.ts
+++ b/packages/groqd/src/commands/subquery/conditional.ts
@@ -100,20 +100,24 @@ function createConditionalParserUnion(
   isExhaustive: boolean
 ) {
   return function parserUnion(input: unknown) {
+    let foundMatch = false;
+    const result = {};
     for (const parser of parsers) {
       try {
-        return parser(input);
+        const parsed = parser(input);
+        Object.assign(result, parsed);
+        foundMatch = true;
       } catch (err) {
         // All errors are ignored,
         // since we never know if it errored due to invalid data,
         // or if it errored due to not meeting the conditional check.
       }
     }
-    if (isExhaustive) {
+    if (isExhaustive && !foundMatch) {
       throw new TypeError(
         `The data did not match any of the ${parsers.length} conditional assertions`
       );
     }
-    return {};
+    return result;
   };
 }

--- a/packages/groqd/src/groq-builder/groq-builder-types.ts
+++ b/packages/groqd/src/groq-builder/groq-builder-types.ts
@@ -32,11 +32,11 @@ export type IGroqBuilder<
   /**
    * The parser function that should be used to parse result data
    */
-  readonly parser: ParserFunction | null;
+  readonly parser: ParserFunction<unknown, TResult> | null;
   /**
    * Parses and validates the query results, passing all data through the parsers.
    */
-  readonly parse: ParserFunction;
+  readonly parse: ParserFunction<unknown, TResult>;
 };
 
 export function isGroqBuilder(
@@ -70,3 +70,8 @@ export type InferResultType<TGroqBuilder extends IGroqBuilder<any>> =
  */
 export type InferResultItem<TGroqBuilder extends IGroqBuilder<any>> =
   ResultItem.Infer<InferResultType<TGroqBuilder>>;
+
+export type InferQueryConfig<TGroqBuilder extends IGroqBuilder<any>> =
+  TGroqBuilder extends IGroqBuilder<any, infer TQueryConfig>
+    ? TQueryConfig
+    : never;

--- a/packages/groqd/src/types/fragment-types.ts
+++ b/packages/groqd/src/types/fragment-types.ts
@@ -2,22 +2,28 @@ import { ExtractProjectionResult } from "./projection-types";
 import { QueryConfig } from "./query-config";
 import { Simplify } from "./utils";
 
-export declare type FragmentMetadata =
-  | typeof FragmentInputTypeTag
-  | typeof FragmentQueryConfigTypeTag;
-declare const FragmentInputTypeTag: unique symbol;
-declare const FragmentQueryConfigTypeTag: unique symbol;
+export declare type FragmentMetadataKeys = typeof BaseType | typeof Config;
+declare const BaseType: unique symbol;
+declare const Config: unique symbol;
+
 /**
- * Represents a projection fragment
+ * This is used to capture metadata for the fragment's base types,
+ * to be extracted later by `InferFragmentType`
+ */
+type FragmentBaseType<TFragmentInput, TQueryConfig extends QueryConfig> = {
+  readonly [BaseType]?: TFragmentInput;
+  readonly [Config]?: TQueryConfig;
+};
+
+/**
+ * A Fragment is an object that can be used in a projection.
  */
 export type Fragment<
-  TFragmentInput, // These are used to capture the type, to be extracted by `InferFragmentType`
+  TFragmentInput,
   TQueryConfig extends QueryConfig,
   TProjectionMap
-> = TProjectionMap & {
-  readonly [FragmentInputTypeTag]?: TFragmentInput;
-  readonly [FragmentQueryConfigTypeTag]?: TQueryConfig;
-};
+> = FragmentBaseType<TFragmentInput, TQueryConfig> & TProjectionMap;
+
 /**
  * Infers the result types of a fragment.
  * @example

--- a/packages/groqd/src/types/fragment-types.ts
+++ b/packages/groqd/src/types/fragment-types.ts
@@ -1,18 +1,22 @@
-/**
- * Used to store the Result types of a Fragment.
- * This symbol is not used at runtime.
- */
-export declare const FragmentResultTypeTag: unique symbol;
+import { ExtractProjectionResult } from "./projection-types";
+import { QueryConfig } from "./query-config";
+import { Simplify } from "./utils";
+
+export declare type FragmentMetadata =
+  | typeof FragmentInputTypeTag
+  | typeof FragmentQueryConfigTypeTag;
+declare const FragmentInputTypeTag: unique symbol;
+declare const FragmentQueryConfigTypeTag: unique symbol;
 /**
  * Represents a projection fragment
  */
 export type Fragment<
-  TFragmentResult,
-  _TFragmentInput, // (this type parameter is only included so that it shows in an IDE)
+  TFragmentInput, // These are used to capture the type, to be extracted by `InferFragmentType`
+  TQueryConfig extends QueryConfig,
   TProjectionMap
 > = TProjectionMap & {
-  // Track the result type, so we can extract it later:
-  readonly [FragmentResultTypeTag]?: TFragmentResult;
+  readonly [FragmentInputTypeTag]?: TFragmentInput;
+  readonly [FragmentQueryConfigTypeTag]?: TQueryConfig;
 };
 /**
  * Infers the result types of a fragment.
@@ -26,9 +30,11 @@ export type Fragment<
  */
 export type InferFragmentType<TFragment extends Fragment<any, any, any>> =
   TFragment extends Fragment<
-    infer TFragmentResult,
-    infer _TFragmentInput,
-    infer _TProjectionMap
+    infer TFragmentInput,
+    infer TQueryConfig,
+    infer TProjectionMap
   >
-    ? TFragmentResult
+    ? Simplify<
+        ExtractProjectionResult<TFragmentInput, TQueryConfig, TProjectionMap>
+      >
     : never;

--- a/packages/groqd/src/types/parser-types.ts
+++ b/packages/groqd/src/types/parser-types.ts
@@ -1,4 +1,4 @@
-import type { ZodType } from "zod";
+import type { ZodType } from "./zod-like";
 
 /**
  * A Parser is either a generic mapping function, or a Zod schema.

--- a/packages/groqd/src/types/projection-types.ts
+++ b/packages/groqd/src/types/projection-types.ts
@@ -16,8 +16,8 @@ import {
   ConditionalKey,
   ExtractConditionalProjectionTypes,
 } from "../commands/subquery/conditional-types";
-import { FragmentResultTypeTag } from "./fragment-types";
 import { IGroqBuilder } from "../groq-builder";
+import { FragmentMetadata } from "./fragment-types";
 
 export type ProjectionMap<TResultItem, TQueryConfig extends QueryConfig> = {
   [P in LiteralUnion<keyof TResultItem, string>]?: ProjectionFieldConfig<
@@ -62,11 +62,8 @@ export type ExtractProjectionResult<
     ExtractProjectionResultFields<
       TResultItem,
       TQueryConfig,
-      // Be sure to omit the Conditionals, "...", and fragment metadata:
-      Omit<
-        TProjectionMap,
-        "..." | typeof FragmentResultTypeTag | ConditionalKey<string>
-      >
+      // Be sure to omit the spread operator, fragment metadata, and Conditionals:
+      Omit<TProjectionMap, "..." | FragmentMetadata | ConditionalKey<string>>
     >
 >;
 

--- a/packages/groqd/src/types/projection-types.ts
+++ b/packages/groqd/src/types/projection-types.ts
@@ -17,7 +17,7 @@ import {
   ExtractConditionalProjectionTypes,
 } from "../commands/subquery/conditional-types";
 import { IGroqBuilder } from "../groq-builder";
-import { FragmentMetadata } from "./fragment-types";
+import { FragmentMetadataKeys } from "./fragment-types";
 
 export type ProjectionMap<TResultItem, TQueryConfig extends QueryConfig> = {
   [P in LiteralUnion<keyof TResultItem, string>]?: ProjectionFieldConfig<
@@ -63,7 +63,10 @@ export type ExtractProjectionResult<
       TResultItem,
       TQueryConfig,
       // Be sure to omit the spread operator, fragment metadata, and Conditionals:
-      Omit<TProjectionMap, "..." | FragmentMetadata | ConditionalKey<string>>
+      Omit<
+        TProjectionMap,
+        "..." | FragmentMetadataKeys | ConditionalKey<string>
+      >
     >
 >;
 

--- a/packages/groqd/src/types/zod-like.ts
+++ b/packages/groqd/src/types/zod-like.ts
@@ -1,0 +1,32 @@
+/**
+ * This file avoids referencing Zod directly,
+ * so that we focus on the bare minimum types needed.
+ */
+
+/**
+ * Represents any Zod-like schema
+ */
+export type ZodType<Output, Def, Input> = {
+  readonly _output: Output;
+  readonly _input: Input;
+  readonly _def: Def;
+  parse(input: unknown, ...params: any[]): Output;
+};
+
+/**
+ * Determines if the error is Zod-like
+ */
+export function isZodError(err: Error): err is ZodError {
+  const errZ = err as ZodError;
+  return (
+    Array.isArray(errZ.errors) &&
+    Array.isArray(errZ.issues) &&
+    typeof errZ.isEmpty === "boolean"
+  );
+}
+
+type ZodError = Error & {
+  errors: Array<{ path: string[]; message: string }>;
+  issues: any[];
+  isEmpty: boolean;
+};

--- a/packages/groqd/src/validation/validation-errors.ts
+++ b/packages/groqd/src/validation/validation-errors.ts
@@ -1,4 +1,4 @@
-import type { ZodError } from "zod";
+import { isZodError } from "../types/zod-like";
 
 export type ErrorDetails = {
   /**
@@ -30,7 +30,7 @@ export class ValidationErrors extends TypeError {
   /**
    * Adds a validation error to the list
    *
-   * @param path - Relative path name for this error (eg. object key, array index)
+   * @param path - Relative path name for this error (e.g. object key, array index)
    * @param value - Actual value at this path
    * @param error - The error - can be a ZodError, another ValidationError, or just any Error object
    */
@@ -93,16 +93,4 @@ function formatPath(paths: PathSegment[]) {
     }
   }
   return res;
-}
-
-/**
- * Determines if the error is Zod-like
- */
-function isZodError(err: Error): err is ZodError {
-  const errZ = err as ZodError;
-  return (
-    Array.isArray(errZ.errors) &&
-    Array.isArray(errZ.issues) &&
-    typeof errZ.isEmpty === "boolean"
-  );
 }

--- a/packages/groqd/src/validation/zod.ts
+++ b/packages/groqd/src/validation/zod.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { ParserFunction } from "../types/parser-types";
 import { pick } from "../types/utils";
+import { ZodType } from "../types/zod-like";
 
 const zodPrimitives = pick(z, [
   "string",
@@ -28,10 +29,10 @@ const zodExtras = {
    * // After:
    * z.default(z.number(), 0)
    */
-  default<TZodSchema extends z.ZodType<any, any, any>>(
-    schema: TZodSchema,
-    defaultValue: z.output<TZodSchema>
-  ): ParserFunction<z.input<TZodSchema> | null, z.output<TZodSchema>> {
+  default<TInput, TOutput>(
+    schema: ZodType<TOutput, any, TInput>,
+    defaultValue: TOutput
+  ): ParserFunction<TInput | null, TOutput> {
     return (input) => {
       if (input === null) return defaultValue;
       return schema.parse(input);


### PR DESCRIPTION
Problem: the Nearform website fails to upgrade from v1.2.0 to v1.3.0.  
Fragments complain about `Type instantiation is excessively deep and possibly infinite.`

This was introduced when trying to make the `Fragment` type more useful. However, that approach was riddled with trouble, and was never quite "ideal".  #365 

This PR reverts that change, simplifying the `Fragment` type which makes large, complex fragments easier to resolve.

# Testing
All unit tests remain the same.  This feature only affects the IDE experience.

This has been tested (via `npm link`) with the Nearform website:
<img width="709" alt="image" src="https://github.com/user-attachments/assets/e9d02361-5fe9-4b11-8f4a-dc83d2ca0231" />
